### PR TITLE
Add Travis CI build matrix to run checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: python
+python:
+  - "3.4"
+  - "3.5"
+  - "3.6"
+install:
+  - make deps
+  - pip install coveralls
+script:
+  - make checks
+after_success:
+  - coveralls

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,24 @@
 venv: FORCE
 	python3 -m venv ~/.venv/cloudmarker
 	echo . ~/.venv/cloudmarker/bin/activate > venv
+
+# In local development environment, we run `make venv` to create a
+# `venv` script that can be used to activate the virtual Python
+# environment conveniently by running `. ./venv`.
+#
+# However, Travis CI creates virtual Python environments on its own for
+# each Python version found in the build matrix. Further, in certain
+# production environments, we may not want to create virtual Python
+# environments.
+#
+# In both of the above mentioned cases, we do not run `make venv`. But
+# most of the commands below start with `. ./venv`, so a `venv` script
+# is expected by all the commands. Therefore, we run `touch venv` to
+# create an empty `venv` script if none exists. If `venv` already
+# exists, then `touch venv` does nothing apart from altering its access
+# and modification times.
+deps: FORCE
+	touch venv
 	. ./venv && pip3 install -r requirements.txt
 	. ./venv && pip3 install -r dev-requirements.txt
 
@@ -10,18 +28,18 @@ rmvenv: FORCE
 test: FORCE
 	. ./venv && python3 -m unittest discover -v
 
-coverage:
+coverage: FORCE
 	. ./venv && coverage run --source . --branch -m unittest discover -v
 	. ./venv && coverage report --show-missing
 	. ./venv && coverage html
 
 # See pylama.ini for pylama configuration.
-lint:
+lint: FORCE
 	. ./venv && pylama cloudmarker
 
 checks: test coverage lint
 
-clean:
+clean: FORCE
 	find . -name "__pycache__" -exec rm -r {} +
 	find . -name "*.pyc" -exec rm {} +
 	rm -rf .coverage htmlcov

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Please follow these steps to setup the development environment:
 
  3. Create a virtual Python environment for development purpose:
 
-        make venv
+        make venv deps
 
  4. Activate the virtual Python environment:
 


### PR DESCRIPTION
The .travis.yml file adds a build matrix that tells Travis CI to run
certain checks (unit tests, test coverage, and linter checks) with
various Python versions.

If the checks succeed, then it posts the test coverage report to
[Coveralls](https://coveralls.io/). Coveralls is a web service that lets
us track code coverage over time and also lets us visualize missed
coverage.

Both Travis CI and Coveralls are free for public repositories on GitHub.