### PR TITLE
Add load_plugin() function in utils module

### DIFF
--- a/cloudmarker/test/test_util.py
+++ b/cloudmarker/test/test_util.py
@@ -7,6 +7,15 @@ from cloudmarker import util
 from cloudmarker.test import data_path
 
 
+class MockPlugin():
+    """A mock plugin to test plugin loading."""
+
+    def __init__(self, a=1, b=2):
+        """Mock initializer."""
+        self.a = a
+        self.b = b
+
+
 class UtilTest(unittest.TestCase):
     """Tests for util module."""
 
@@ -16,6 +25,39 @@ class UtilTest(unittest.TestCase):
         path3 = os.path.join(data_path, 'missing.yaml')
         config = util.load_config([path1, path2, path3])
         self.assertEqual(config, {'foo': 'bar', 'baz': 'qux'})
+
+    def test_load_plugin_syntax_error(self):
+        with self.assertRaises(util.PluginError):
+            util.load_plugin({'plugin': 'foo'})
+
+    def test_load_plugin_missing_error(self):
+        plugin_config = {
+            'plugin': 'cloudmarker.test.test_util.MissingPlugin'
+        }
+        with self.assertRaises(AttributeError):
+            util.load_plugin(plugin_config)
+
+    def test_load_plugin_without_params(self):
+        plugin_config = {
+            'plugin': 'cloudmarker.test.test_util.MockPlugin'
+        }
+        plugin = util.load_plugin(plugin_config)
+        self.assertIsInstance(plugin, MockPlugin)
+        self.assertEqual(plugin.a, 1)
+        self.assertEqual(plugin.b, 2)
+
+    def test_load_plugin_with_params(self):
+        plugin_config = {
+            'plugin': 'cloudmarker.test.test_util.MockPlugin',
+            'params': {
+                'a': 3,
+                'b': 4,
+            }
+        }
+        plugin = util.load_plugin(plugin_config)
+        self.assertIsInstance(plugin, MockPlugin)
+        self.assertEqual(plugin.a, 3)
+        self.assertEqual(plugin.b, 4)
 
     def test_parse_cli_args_none(self):
         args = util.parse_cli([])

--- a/pylama.ini
+++ b/pylama.ini
@@ -10,7 +10,8 @@ ignore = D203,D213,D406,D407,C0103,W0511
 # W0511 TODO: [pylint]
 
 [pylama:cloudmarker/test/test_*.py]
-ignore = D102,C0111
+ignore = D102,C0111,R0903
 
 # D102 Missing docstring in public method [pydocstyle]
 # C0111 Missing method docstring [pylint]
+# R0903 Too few public methods (0/2) [pylint]


### PR DESCRIPTION
The load_plugin() function will be used to instantiate plugin classes
with parameters specified in the configuration.