### PR TITLE
Add mock plugins and invoke them from manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-Cloud Marker
+Cloudmarker
 ============
 
-Cloud Marker is a cloud security monitoring framework.
+Cloudmarker is a cloud security monitoring framework.
 
 
 Setup Development Environment
@@ -30,7 +30,7 @@ Please follow these steps to setup the development environment:
 
         python3 -m cloudmarker
 
-    Right now, it just reads a default configuration and prints it. More
+    Right now, it generates mock data at `/tmp/cloudmarker`. More
     functionality will be added later.
 
  6. Run the unit tests, code coverage, and linters:

--- a/cloudmarker/checks/mockcheck.py
+++ b/cloudmarker/checks/mockcheck.py
@@ -1,0 +1,41 @@
+"""Mock check plugin for testing purpose."""
+
+
+class MockCheck:
+    """Mock check plugin for testing purpose."""
+
+    def __init__(self, n=3):
+        """Initialize object of this class with specified parameters.
+
+        This is a mock check for mock records only that checks if the
+        record number in the mock record is a multiple of ``n``.
+
+        Arguments:
+            n (int): A number that the record number in mock record must
+                be a multiple of in order to generate an event record.
+
+        """
+        self._n = n
+
+    def eval(self, record):
+        """Evaluate record to check for multiples of n.
+
+        Arguments:
+            record (dict): Record to evaluate.
+
+        Yields:
+            dict: An event record whenever the check rule matches the
+                input record being evaluated.
+
+        """
+        # If record number is a multiple of self._n, generate an event
+        # record.
+        if record.get('record_num', 1) % self._n == 0:
+            yield {
+                'record_type': 'mock_event',
+                'n': self._n,
+                'cloud_record': record,
+            }
+
+    def done(self):
+        """Perform clean up tasks."""

--- a/cloudmarker/clouds/mockcloud.py
+++ b/cloudmarker/clouds/mockcloud.py
@@ -1,0 +1,49 @@
+"""Mock cloud plugin for testing purpose."""
+
+
+class MockCloud:
+    """Mock cloud plugin for testing purpose."""
+
+    def __init__(self, record_count=10, record_types=('foo', 'bar')):
+        """Initialize object of this class with specified parameters.
+
+        Arguments:
+            record_count (int): Number of mock records to generate.
+            record_types (tuple): A tuple of strings that represent the
+                different record types to be generated.
+
+        """
+        self._record_count = record_count
+        self._record_types = record_types
+
+    def read(self):
+        """Return a record.
+
+        This method creates and yields mock records.
+
+        In actual cloud implementations, this method would connect to
+        the cloud, retrieve JSON objects using the cloud API, and yield
+        those objects.
+
+        Yields:
+            dict: Mock record.
+
+        """
+        # We try hard to keep the cloud plugins decoupled from plugins.
+        # In general, we try hard to keep one plugin decoupled from
+        # another plugin. However, there is still minimal coupling
+        # between plugins that is unavoidable. For example, each store
+        # type needs to know the type of record it is dealing with in
+        # order to classify the record and put it in the right bucket
+        # (an index, file, directory, etc.). Therefore, the cloud plugin
+        # puts some additional metadata such as record_type into the
+        # record that other plugins can rely on.
+        n = len(self._record_types)
+        for i in range(self._record_count):
+            yield {
+                'record_num': i,
+                'record_type': self._record_types[i % n],
+            }
+
+    def done(self):
+        """Perform clean up tasks."""

--- a/cloudmarker/manager.py
+++ b/cloudmarker/manager.py
@@ -15,4 +15,87 @@ def main():
     """Run the framework."""
     args = util.parse_cli()
     config = util.load_config(args.config)
-    print(config)
+    audits = _create_audit_plugins(config)
+    _run_audits(audits)
+
+
+def _create_audit_plugins(config):
+    """Read configuration and construct all plugins.
+
+    Arguments:
+        config (dict): Framework configuration
+
+    Returns:
+        list: A list of tuples. Each tuple is of the format
+            (cloud_plugin, store_plugins, check_plugins, alert_plugins) where
+            store_plugins, check_plugins, and alert_plugins are lists of
+            plugins of respective types.
+
+    """
+    audits = []
+
+    for audit_name in config['run']:
+        for cloud_name in config['audits'][audit_name]['clouds']:
+
+            cloud_plugin = util.load_plugin(config['clouds'][cloud_name])
+
+            store_plugins = [
+                util.load_plugin(config['stores'][store_name])
+                for store_name in config['audits'][audit_name]['stores']
+            ]
+
+            check_plugins = [
+                util.load_plugin(config['checks'][store_name])
+                for store_name in config['audits'][audit_name]['checks']
+            ]
+
+            alert_plugins = [
+                util.load_plugin(config['alerts'][store_name])
+                for store_name in config['audits'][audit_name]['alerts']
+            ]
+
+            audits.append((cloud_plugin, store_plugins, check_plugins,
+                           alert_plugins))
+
+    return audits
+
+
+def _run_audits(audits):
+    """Run all plugins to perform auditing.
+
+    Arguments:
+        audits (list): A list returned by _create_audit_plugins.
+
+    """
+    # For each cloud configured for auditing ...
+    for cloud, stores, checks, alerts in audits:
+
+        # For each cloud record read from the cloud ...
+        for cloud_record in cloud.read():
+
+            # Write the record in each configured store.
+            for store in stores:
+                store.write(cloud_record)
+
+            # Also feed the record to each checker.
+            for check in checks:
+
+                # For each anomaly record obtained from checker ...
+                for check_record in check.eval(cloud_record):
+
+                    # Send each check record as an alert.
+                    for alert in alerts:
+                        alert.write(check_record)
+
+        # Tell each plugin that there is nothing more to do, so that
+        # they perform any final cleanup tasks.
+        cloud.done()
+
+        for check in checks:
+            check.done()
+
+        for store in stores:
+            store.done()
+
+        for alert in alerts:
+            alert.done()

--- a/cloudmarker/stores/filestore.py
+++ b/cloudmarker/stores/filestore.py
@@ -1,0 +1,80 @@
+"""Filesystem store plugin."""
+
+
+import json
+import os
+
+
+class FileStore:
+    """A plugin to store records on the filesystem."""
+
+    def __init__(self, path='/tmp/cloudmarker'):
+        """Initialize object of this class with specified parameters.
+
+        Arguments:
+            path (str): Path of directory where files are written to.
+
+        """
+        self._path = path
+        self._record_types = set()
+        os.makedirs(path, exist_ok=True)
+
+    def write(self, record):
+        """Write JSON records to the file system.
+
+        This method is called once for every record read from a cloud.
+        In this example implementation of a store, we simply write the
+        record in JSON format to a file. The list of records is
+        maintained as JSON array in the file. The record type is used to
+        determine the filename.
+
+        The records are written to a .tmp file because we don't want to
+        delete the existing complete and useful .json file prematurely.
+
+        Note that other implementations of a store may choose to buffer
+        the records in memory instead of writing each record to the
+        store immediately. They may then flush the buffer to the store
+        based on certain conditions such as buffer size, time interval,
+        etc.
+
+        Arguments:
+            record (dict): Data to write to the file system.
+
+        """
+        record_type = record['record_type']
+
+        # If this is the first time we have encountered this
+        # record_type, we create a new file for it and write an opening
+        # bracket to start a JSON array.
+        tmp_file_path = os.path.join(self._path, record_type) + '.tmp'
+        if record_type not in self._record_types:
+            with open(tmp_file_path, 'w') as f:
+                f.write('[\n')
+
+        # Write the record dictionary as JSON object literal.
+        self._record_types.add(record_type)
+        with open(tmp_file_path, 'a') as f:
+            f.write(json.dumps(record, indent=2) + ',\n')
+
+    def done(self):
+        """Perform final cleanup tasks.
+
+        This method is called after all records have been written. In
+        this example implementation, we properly terminate the JSON
+        array in the .tmp file. Then we rename the .tmp file to .json
+        file.
+
+        Note that other implementations of a store may perform tasks
+        like closing a connection to a remote store or flushing any
+        remaining records in a buffer.
+
+        """
+        for record_type in self._record_types:
+            # End the JSON array by writing a closing bracket.
+            tmp_file_path = os.path.join(self._path, record_type) + '.tmp'
+            with open(tmp_file_path, 'a') as f:
+                f.write(']\n')
+
+            # Rename the temporary file to a JSON file.
+            json_file_path = os.path.join(self._path, record_type) + '.json'
+            os.rename(tmp_file_path, json_file_path)

--- a/config.base.yaml
+++ b/config.base.yaml
@@ -1,18 +1,29 @@
-stores:
-  filestore:
-    plugin: cloudmarker.stores.filestore.FileStore
-    params:
-      path: '/tmp/cloudmarker'
-
 clouds:
   mockcloud:
     plugin: cloudmarker.clouds.mockcloud.MockCloud
 
-mockjob:
-  clouds:
-    - mockcloud
-  stores:
-    - filestore
+stores:
+  filestore:
+    plugin: cloudmarker.stores.filestore.FileStore
 
-jobs:
-  - mockjob
+checks:
+  mockcheck:
+    plugin: cloudmarker.checks.mockcheck.MockCheck
+
+alerts:
+  filestore:
+    plugin: cloudmarker.stores.filestore.FileStore
+
+audits:
+  mockaudit:
+    clouds:
+      - mockcloud
+    stores:
+      - filestore
+    checks:
+      - mockcheck
+    alerts:
+      - filestore
+
+run:
+  - mockaudit


### PR DESCRIPTION
This change adds a few mock plugins to explore the design that is
evolving for this project. So far we have four types of plugins:
clouds, stores, checks, and alerts.

Here is a brief overview of how these plugins interact with each other:
Data is read from clouds and fed to stores and checks. Checks evaluate
the records that they are fed with and generate events when a check-rule
matches a record. These events are sent as alerts to destination stores
or recipients.