### PR TITLE
Run plugins in separate worker subprocesses

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[run]
+source = .
+concurrency = multiprocessing
+branch = true

--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,17 @@ coverage: FORCE
 	. ./venv && coverage report --show-missing
 	. ./venv && coverage html
 
-# See pylama.ini for pylama configuration.
+# See pylama.ini for pylama configuration. Pylama is configured to
+# invoke isort to lint import statements. Pylama prints the files where
+# we need to fix the import statements. But it does not tell us the
+# details of the changes to be made to fix them.
+#
+# This is why we invoke isort independently once to show us the changes
+# (in diff format) that we need to make to fix the import statements.
+# Note that this independently invoked isort exits with exit code 0
+# regardless of whether it finds problems with import statements or not.
 lint: FORCE
+	. ./venv && isort --quiet --diff
 	. ./venv && pylama cloudmarker
 
 checks: test coverage lint

--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,11 @@ rmvenv: FORCE
 	rm -rf ~/.venv/cloudmarker
 
 test: FORCE
-	. ./venv && python3 -m unittest discover -v
+	. ./venv && python3 -m unittest -v
 
 coverage: FORCE
-	. ./venv && coverage run --source . --branch -m unittest discover -v
+	. ./venv && coverage run -m unittest -v
+	. ./venv && coverage combine
 	. ./venv && coverage report --show-missing
 	. ./venv && coverage html
 

--- a/cloudmarker/test/test_main.py
+++ b/cloudmarker/test/test_main.py
@@ -1,0 +1,18 @@
+"""Tests for package execution."""
+
+
+import unittest
+from unittest import mock
+
+
+class MainTest(unittest.TestCase):
+    """Tests for package execution."""
+
+    @mock.patch('sys.argv', ['cloudmarker', '-c', 'config.base.yaml'])
+    def test_main(self):
+        # Run cloudmarker package with only the default base
+        # configuration and ensure that it runs without issues.
+        import cloudmarker.__main__
+
+        # Check that __version__ is defined.
+        self.assertTrue(len(cloudmarker.__main__.__version__) > 0)

--- a/cloudmarker/test/test_workers.py
+++ b/cloudmarker/test/test_workers.py
@@ -1,0 +1,97 @@
+"""Tests for worker functions."""
+
+
+import multiprocessing as mp
+import unittest
+from unittest import mock
+
+from cloudmarker import workers
+
+
+class WorkersTest(unittest.TestCase):
+    """Tests for worker functions."""
+
+    def test_cloud_worker(self):
+        # Mock plugin that generates two string records.
+        plugin = mock.Mock()
+        plugin.read = mock.Mock(return_value=['record1', 'record2'])
+
+        # Test output queues for the mock plugin.
+        out_q1 = mp.Queue()
+        out_q2 = mp.Queue()
+
+        # Invoke the mock plugin with the worker.
+        workers.cloud_worker('foo', plugin, [out_q1, out_q2])
+
+        # Test that the worker has put the two string records in both
+        # the test output queues.
+        self.assertEqual(out_q1.get(), 'record1')
+        self.assertEqual(out_q1.get(), 'record2')
+        self.assertEqual(out_q2.get(), 'record1')
+        self.assertEqual(out_q2.get(), 'record2')
+
+    def test_store_worker(self):
+        # Mock plugin.
+        plugin = mock.Mock()
+
+        # Test input queue for the mock plugin.
+        in_q = mp.Queue()
+
+        # Put two string records and None in the test input queue.
+        in_q.put('record1')
+        in_q.put('record2')
+        in_q.put(None)
+
+        # Invoke the mock plugin with the worker.
+        workers.store_worker('foo', plugin, in_q)
+
+        # Test that the worker invoked the mock plugin's write()
+        # method twice (once with each string record) and finally
+        # invoked the mock plugin's done() method (for the None input).
+        expected_calls = [mock.call.write('record1'),
+                          mock.call.write('record2'),
+                          mock.call.done()]
+        self.assertEqual(plugin.mock_calls, expected_calls)
+
+    def test_check_worker(self):
+        # A fake_eval function that returns two fake records: length of
+        # input string, and upper-cased input string.
+        def fake_eval(s):
+            yield len(s)
+            yield s.upper()
+
+        # Mock plugin.
+        plugin = mock.Mock()
+        plugin.eval = mock.Mock(side_effect=fake_eval)
+
+        # Test input queue and output queues for the mock plugin.
+        in_q = mp.Queue()
+        out_q1 = mp.Queue()
+        out_q2 = mp.Queue()
+
+        # Put two string records and None in the tet input queue.
+        in_q.put('record1')
+        in_q.put('record2')
+        in_q.put(None)
+
+        # Invoke the mock plugin with the worker.
+        workers.check_worker('foo', plugin, in_q, [out_q1, out_q2])
+
+        # Test that the worker invoked the mock plugin's eval() method
+        # twice (once for each input string record) and finally invokd
+        # the mock plugin's done() method (for the None input).
+        expected_calls = [mock.call.eval('record1'),
+                          mock.call.eval('record2'),
+                          mock.call.done()]
+        self.assertEqual(plugin.mock_calls, expected_calls)
+
+        # Test that the worker has put the values yielded by fake_eval
+        # in the test output queues.
+        self.assertEqual(out_q1.get(), 7)
+        self.assertEqual(out_q1.get(), 'RECORD1')
+        self.assertEqual(out_q1.get(), 7)
+        self.assertEqual(out_q1.get(), 'RECORD2')
+        self.assertEqual(out_q2.get(), 7)
+        self.assertEqual(out_q2.get(), 'RECORD1')
+        self.assertEqual(out_q2.get(), 7)
+        self.assertEqual(out_q2.get(), 'RECORD2')

--- a/cloudmarker/workers.py
+++ b/cloudmarker/workers.py
@@ -1,0 +1,66 @@
+"""Worker functions.
+
+The functions in this module wrap around plugin classes such that these
+worker functions can be specified as the ``target`` parameter while
+launching a new process with ``multiprocessing.Process``.
+
+Each worker function can run as a separate process. While wrapping
+around a plugin class, each worker function creates the appropriate
+multiprocessing queues to pass records from one plugin class to another.
+"""
+
+
+def cloud_worker(worker_name, cloud_plugin, output_queues):
+    """Cloud worker function.
+
+    Arguments:
+        worker_name (str): Display name for the worker.
+        cloud_plugin (object): Cloud plugin object.
+        output_queues (list): List of mp.Queue objects to write records to.
+    """
+    print('%s: Started' % worker_name)
+    for record in cloud_plugin.read():
+        for q in output_queues:
+            q.put(record)
+    print('%s: Stopped' % worker_name)
+
+
+def store_worker(worker_name, store_plugin, input_queue):
+    """Store worker function.
+
+    Arguments:
+        worker_name (str): Display name for the worker.
+        store_plugin (object): Store plugin object.
+        input_queue (multiprocessing.Queue): Queue to read records from.
+    """
+    print('%s: Started' % worker_name)
+    while True:
+        record = input_queue.get()
+        if record is None:
+            store_plugin.done()
+            break
+        store_plugin.write(record)
+    print('%s: Stopped' % worker_name)
+
+
+def check_worker(worker_name, check_plugin, input_queue, output_queues):
+    """Check worker function.
+
+    Arguments:
+        worker_name (str): Display name for the worker.
+        store_plugin (object): Store plugin object.
+        input_queue (multiprocessing.Queue): Queue to read records from.
+        output_queues (list): List of queues to write event records to.
+    """
+    print('%s: Started' % worker_name)
+    while True:
+        record = input_queue.get()
+        if record is None:
+            check_plugin.done()
+            break
+
+        for event_record in check_plugin.eval(record):
+            for q in output_queues:
+                q.put(event_record)
+
+    print('%s: Stopped' % worker_name)


### PR DESCRIPTION
There are three changes in this pull request. In chronological order (earliest to latest), they are:

- Run plugins in separate worker subprocesses
- Measure code coverage in subprocesses
- Invoke isort independently on running lint target


## Run plugins in separate worker subprocesses

This change enhances the `manager` module to invoke plugin methods in separate subprocesses. This allows all plugins to run in parallel. Records generated by one plugin is fed to another plugin via queues (`multiprocessing.Queue` objects).

In the configuration file, there is an `audits` key which may contain multiple audit keys, e.g., `mockaudit`, `myaudit`, etc. Each such audit key defines a single audit definition. A single audit definition specifies cloud plugins, store plugins, check plugins, and alert plugins.

All of these plugins together under a single audit key form a single audit definition. Multiple such audit definitions may be present under the "audits" key in the configuration.

Here is how data flows between the various plugins within a single audit definition:

                       ,----> Store Plugins
    Cloud Plugins ----|
                       `----> Check Plugins ----> Alert Plugins

Here is a detailed description of the above diagram:

  - At first, the cloud plugins retrieve (`read`) cloud configuration and metadata records from their respective clouds. All of these records from all cloud plugins are then fed to all store plugins and all store check plugins defined within the same audit definition.

  - Each store plugin would then typically store (`write`) these records to a persistent data store.

  - Each check plugin would evaluate (`eval`) each record to check for any interesting properties of the records. Typically, a check plugin would look for security misconfigurations in a record. For every such security misconfiguration or any other interesting property detected in a record, it may generate one or more event records. These event records are then fed to alert plugins.

  - Each alert plugin would then typically send or store (`write`) these records to a receiver or persistent data store, respectively.

There are a few more important points to note:

  - The plugins in one audit definition and the plugins in another audit definition are completely independent of each other. The plugins in one audit definition cannot send/receive data to/from plugins in another audit definition. This allows each store or alert plugin to clear or reset their data store when an audit starts without losing the data obtained with an independent audit definition.

  - A store plugin is also a valid alert plugin because both of them must implement the same methods: `write` and `done`.

  - The plugins have no knowledge of each other. Each plugin only accepts and/or generates data that it is concerned with. They do not interact with another plugin. Thus, every arrow in the above ASCII diagram is a bit misleading. They are not direct connections from one plugin to another. There is always the `manager` module in between that takes data from one plugin and feeds it to another plugin.


## Measure code coverage in subprocesses

Prior to this change, the following commands in `Makefile` do not measure code coverage in subprocesses.

    coverage run --source . --branch -m unittest discover -v
    coverage report --show-missing
    coverage html

The coverage results can be seen on the terminal as the output of `coverage report --show-missing` and as HTML in `htmlcov/index.html`.

With the above commands, we see missed coverage for lines of code in `mockcloud.read`, `mockcheck.eval`, `filestore.write`, and `filestore.done`, even though these code lines were exercised indirectly from `cloudmarker/test/test_main.py`.

This issue occurs because these lines of code are not executed within the main process. Instead, they are exercised from the workers launched as separate processes using `multiprocessing.Process`. The `coverage` tool does not measure code execution in subprocesses by default. It has to be run with `--concurrency=multiprocessing` to measure code execution in subprocesses. But doing so leads to another issue:

    $ coverage run --source=. --concurrency=multiprocessing --branch \
      -m unittest discover -v
    Options affecting multiprocessing must be specified in a
    configuration file.
    Use 'coverage help' for help.

If we use `--concurrency` in the command line option, other options like `--source` and `--branch` must be specified in a configuration file (`.coveragerc` by default). This is the reason why `.coveragerc` has been introduced in this change.

See comments by Ned Batchelder, the author of `coverage`, at <https://stackoverflow.com/a/52379777/303363> for some more information about this.

This simplifies the `coverage` command in the `Makefile` because most of the command line options have now moved to `.coveragerc`.

Additionally, in favour of simplifying the `coverage` command further, the `discover` argument to `unittest` module has been removed in the `Makefile` because test discovery is the default behaviour of the `unittest` module. Here is the relevant excerpt from <https://docs.python.org/3/library/unittest.html>:

> When executed without arguments Test Discovery is started:
>
>     python -m unittest


## Invoke isort independently on running lint target

Pylama is configured to invoke isort to lint import statements already. As a result, it prints the files where we need to fix the import statements. But it does not tell us in detail exactly what changes we need to make to fix the import statements.

Therefore, in this change, we invoke isort independently to show us the changes (in diff format) that we need to make to fix the import statements.

This independently invoked isort exits with exit code 0 regardless of whether it finds problems with import statements or not. So it does not prevent the subsequent Pylama command from running even if it finds problems with the import statements.