### PR TITLE
Ignore proprietary format coverage files created

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Ignore automatically generated files.
 venv
 .coverage
+.coverage.*
 htmlcov/
 
 # Ignore local development files.

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,6 @@ checks: test coverage lint
 clean: FORCE
 	find . -name "__pycache__" -exec rm -r {} +
 	find . -name "*.pyc" -exec rm {} +
-	rm -rf .coverage htmlcov
+	rm -rf .coverage.* .coverage htmlcov
 
 FORCE:


### PR DESCRIPTION
when running the command
. ./venv && coverage run -m unittest -v
creates temp files of the format .coverage.HOSTNAME.NUM.NUM

Modified the Makefile to use a ".coverage.*" pattern to remove files and
updated the same in .gitignore