### PR TITLE
MongoDBStore enhancements: arbitrarily ordered insertion, parameter list, single MongoClient statement

### DIFF
--- a/cloudmarker/stores/mongodbstore.py
+++ b/cloudmarker/stores/mongodbstore.py
@@ -11,19 +11,22 @@ _log = logging.getLogger(__name__)
 class MongoDBStore:
     """A plugin to store records on MongoDB."""
 
-    def __init__(self, host, port, username=None, password=None, db='gcp',
+    def __init__(self, db, username, password, host, port=27017,
                  buffer_size=1000):
         """Create an instance of :class:`MongoDBStore` plugin.
 
-        Arguments:
-            host (str): MongoDB instance host.
-            port (int): MongoDB instance port.
-            username (str): MongoDB instance auth username.
-            password (str): MongoDB instance auth password.
-            db (str): MongoDB database name, default: ``gcp``
-            buffer_size (int): Max number of records to hold in memeory for
-                each record_type.
+        It will use the default port for mongodb 27017 if not specified.
+        The Authentication scheme will be negotiated by MongoDB and the client
+        for v4.0+ to SCRAM-SHA-1 or SCRAM-SHA-256 by default aftere
+        negotiation.
 
+        Arguments:
+            db (str): name of the database
+            username (str): username for the database
+            password (str): password for username to authenticate with the db
+            host (str): hostname for the DB server
+            port (int): port for mongoDB is listening, defaults to 27017
+            buffer_size (int): max buffer before flushing to db
         """
         # pylint: disable=too-many-instance-attributes
 
@@ -33,8 +36,8 @@ class MongoDBStore:
         self._mongodb_password = password
         self._db = db
 
-        self._buffer_size = buffer_size
         self._buffer = {}
+        self._buffer_size = buffer_size
 
         if not (username and password):
             self._client = MongoClient(host=self._mongodb_host,

--- a/pylama.ini
+++ b/pylama.ini
@@ -16,8 +16,7 @@ ignore = E1101
 # E1101 Instance of 'Resource' has no 'instances' member [pylint]
 
 [pylama:cloudmarker/stores/mongodbstore.py]
-ignore = R0902,R0913 
-# R0902 Too many instance attributes (8/7)
+ignore = R0913 
 # R0913 Too many arguments (7/5)
 
 [pylama:cloudmarker/test/test_*.py]


### PR DESCRIPTION
Updated the MongoDBStore Plugin initialization params sequence to make it more intuitive.
1. `db`: name of the database, as this is the natural level of separation in a shared DB
2. `username`: For a shared DB, username is required
3. `password`: Required Authentication
4. `host`: defaults to localhost, but should be required only after authentication information if it's a remote DB
5. `port`: default 27017 port for localhost, or an specific port 
6. `buffer_size`: As this is just a buffering param, can be left to default

Change the mode of `insert_many` to `ordered=False`, as the default behavious allows the driver to insert the documents in order and fail at the first failure. By making it False, the driver will try to insert data in an unordered format and will try insertion for all documents at least once, possibly in parallel.
[insert_many](http://api.mongodb.com/python/current/api/pymongo/collection.html#pymongo.collection.Collection.insert_many).

To handle the failed insertions due to error, surround the `insert_many` with try-catch and log the incident.

Close the connection when `done` is called.