### PR TITLE
MongoDB Store Plugin Integration Tests

### DIFF
--- a/cloudmarker/stores/mongodbstore.py
+++ b/cloudmarker/stores/mongodbstore.py
@@ -46,13 +46,13 @@ class MongoDBStore:
         # done with the following way. The object specified must have the
         # following functions:
         #     collection(): returns the name of the collection
-        #     validator(): returns a valid string with $jsonSchema that contains
-        #         all the validation properties as specified in the mongodb
-        #         docs.
+        #     validator(): returns a valid string with $jsonSchema that
+        #         contains all the validation properties as specified in the
+        #         mongodb docs.
         #     enforce(): returns one of the strings ``error`` or ``warn``.
-        #         This will be used to define the error level for when the schema
-        #         validation fails. ``error`` will raise an error while ``warn``
-        #         will log that violation in the db server logs.
+        #         This will be used to define the error level for when the
+        #         schema validation fails. ``error`` will raise an error while
+        #         ``warn`` will log that violation in the db server logs.
         for model in kwargs.get('models', []):
             if model.collection() not in self._db.list_collection_names():
                 self._db.create_collection(

--- a/cloudmarker/stores/mongodbstore.py
+++ b/cloudmarker/stores/mongodbstore.py
@@ -12,7 +12,7 @@ class MongoDBStore:
     """A plugin to store records on MongoDB."""
 
     def __init__(self, db, username, password, host, port=27017,
-                 buffer_size=1000):
+                 buffer_size=1000, **kwargs):
         """Create an instance of :class:`MongoDBStore` plugin.
 
         It will use the default port for mongodb 27017 if not specified.
@@ -27,6 +27,9 @@ class MongoDBStore:
             host (str): hostname for the DB server
             port (int): port for mongoDB is listening, defaults to 27017
             buffer_size (int): max buffer before flushing to db
+            kwargs (dict): Additional args
+                * models - List of classes for validator and enforcement
+                    requirements.
         """
         self._client = MongoClient(
             host=host,
@@ -36,6 +39,27 @@ class MongoDBStore:
         )
 
         self._db = self._client[db]
+
+        # Create collections if they don't exist based on the document
+        # restrictions the users want to have.
+        # The collection creation, where the models objects specified, are
+        # done with the following way. The object specified must have the
+        # following functions:
+        #     collection(): returns the name of the collection
+        #     validator(): returns a valid string with $jsonSchema that contains
+        #         all the validation properties as specified in the mongodb
+        #         docs.
+        #     enforce(): returns one of the strings ``error`` or ``warn``.
+        #         This will be used to define the error level for when the schema
+        #         validation fails. ``error`` will raise an error while ``warn``
+        #         will log that violation in the db server logs.
+        for model in kwargs.get('models', []):
+            if model.collection() not in self._db.list_collection_names():
+                self._db.create_collection(
+                    model.collection(),
+                    validator=model.validator(),
+                    validationAction=model.enforce()
+                )
 
         self._buffer = {}
         self._buffer_size = buffer_size
@@ -102,6 +126,6 @@ class MongoDBStore:
         for record_type, records in self._buffer.items():
             self._flush(record_type, records)
 
-        # Close the mongo db connection when done is called as this will be the
+        # Close the MongoDB connection when done is called as this will be the
         # last call to the store plugin.
         self._client.close()

--- a/cloudmarker/stores/mongodbstore.py
+++ b/cloudmarker/stores/mongodbstore.py
@@ -28,29 +28,17 @@ class MongoDBStore:
             port (int): port for mongoDB is listening, defaults to 27017
             buffer_size (int): max buffer before flushing to db
         """
-        # pylint: disable=too-many-instance-attributes
+        self._client = MongoClient(
+            host=host,
+            port=port,
+            username=username,
+            password=password
+        )
 
-        self._mongodb_host = host
-        self._mongodb_port = port
-        self._mongodb_username = username
-        self._mongodb_password = password
-        self._db = db
+        self._db = self._client[db]
 
         self._buffer = {}
         self._buffer_size = buffer_size
-
-        if not (username and password):
-            self._client = MongoClient(host=self._mongodb_host,
-                                       port=self._mongodb_port,
-                                       connect=False)
-        else:
-            self._client = MongoClient(host=self._mongodb_host,
-                                       port=self._mongodb_port,
-                                       username=username,
-                                       password=password,
-                                       authSource=self._db,
-                                       authMechanism='SCRAM-SHA-256',
-                                       connect=False)
 
     def _flush(self, record_type, records):
         """Perform bulk insert of buffered records into MongoDB collection.
@@ -113,3 +101,7 @@ class MongoDBStore:
         # Flush all the residual records buffers to mongodb collections
         for record_type, records in self._buffer.items():
             self._flush(record_type, records)
+
+        # Close the mongo db connection when done is called as this will be the
+        # last call to the store plugin.
+        self._client.close()

--- a/cloudmarker/test/data/docker-compose.yml
+++ b/cloudmarker/test/data/docker-compose.yml
@@ -1,0 +1,35 @@
+# Use root/example as user/password credentials
+version: '3.1'
+
+services:
+
+  mongo:
+    image: mongo
+    restart: always
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: dummy
+      MONGO_INITDB_ROOT_PASSWORD: password
+    ports:
+      - 27017:27017
+    networks:
+      mynet:
+        ipv4_address: 172.16.101.2
+
+  mongo-express:
+    image: mongo-express
+    restart: always
+    ports:
+      - 8081:8081
+    environment:
+      ME_CONFIG_MONGODB_ADMINUSERNAME: dummy
+      ME_CONFIG_MONGODB_ADMINPASSWORD: password
+    networks:
+      mynet:
+        ipv4_address: 172.16.101.3
+
+networks:
+  mynet:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.16.101.0/24

--- a/cloudmarker/test/test_mongostore.py
+++ b/cloudmarker/test/test_mongostore.py
@@ -1,0 +1,205 @@
+"""Tests for MongoDB store plugin."""
+
+
+import unittest
+from collections import defaultdict
+
+from pymongo import MongoClient
+
+from cloudmarker.stores import mongodbstore
+
+
+class DummyModel:
+    """A DummyModel to demonstrate constraint validation."""
+
+    __COLLECTION__ = "test_collection"
+    __ENFORCE__ = "error"  # ["error", "warn"]
+    __VALIDATOR__ = {
+        "$jsonSchema": {
+            "bsonType": "object",
+            "required": ["name"],
+            "properties": {
+                "name": {
+                    "bsonType": "string",
+                    "minLength": 3,
+                    "maxLength": 63,
+                    "description": "Name of the user, 2 < length < 64,required"
+                }
+            }
+        }
+    }
+
+    def __init__(self, name="", attr=defaultdict()):
+        """Initialize the DummyModel object for test."""
+        self.name = name
+        self.attr = attr
+
+    @staticmethod
+    def validator():
+        return DummyModel.__VALIDATOR__
+
+    @staticmethod
+    def enforce():
+        return DummyModel.__ENFORCE__
+
+    @staticmethod
+    def collection():
+        return DummyModel.__COLLECTION__
+
+    def marshal(self):
+        mp = {
+            "name": self.name
+        }
+
+        for k, v in self.attr.items():
+            mp[k] = v
+
+        mp["record_type"] = DummyModel.collection()
+
+        return mp
+
+
+class MongoDBStoreTest(unittest.TestCase):
+    """Tests for MongoDB store plugin.
+
+    All tests would require a running instance of mongoDB. You may use
+    the docker compose file in ``cloudmarker/test/data/docker-comppose.yml``
+    $ docker-compute -f cloudmarker/test/data/docker-comppose.yml up
+    """
+
+    def test_connection(self):
+        client = MongoClient(host='localhost', port=27017,
+                             username='dummy', password='password')
+
+        db = client["test"]
+
+        for collection in db.list_collection_names():
+            db[collection].drop()
+
+        store = mongodbstore.MongoDBStore('test', 'dummy',
+                                          'password', 'localhost')
+        compute = {
+            "record_type": "compute",
+            "id": "sample/compute/compute_1",
+            "compute_name": "testing",
+            "machine_size": "MX",
+            "provisioning_state": "done"
+        }
+
+        nic = {
+            "record_type": "nic",
+            "compute_id": "sample/compute/compute_1",
+            "id": "sample/compute/nic_2",
+            "mac": "aa:aa:aa:aa:aa:aa",
+            "provisioning_state": "done",
+            "ip": [
+                {
+                    "id": "sample/compute/nic_2/ip_1",
+                    "primary": True,
+                    "private_ip": "10.0.0.1",
+                    "private_ip_version": "IPv4",
+                    "private_ip_allocation": "dynamic",
+                    "public_ip": "123.123.123.123"
+                },
+                {
+                    "id": "sample/compute/nic_2/ip_2",
+                    "primary": False,
+                    "private_ip": "10.0.0.2",
+                    "private_ip_version": "IPv4",
+                    "private_ip_allocation": "dynamic"
+                }
+            ]
+        }
+
+        store.write(compute)
+        store.write(nic)
+
+        store.done()
+
+        self.assertEqual(db['compute'].count_documents({}), 1)
+        self.assertEqual(db['nic'].count_documents({}), 1)
+
+    def test_valid_insert(self):
+        client = MongoClient(host='localhost', port=27017,
+                             username='dummy', password='password')
+
+        db = client["test"]
+
+        for collection in db.list_collection_names():
+            db[collection].drop()
+
+        store = mongodbstore.MongoDBStore('test', 'dummy', 'password',
+                                          'localhost', 27017,
+                                          models=[DummyModel])
+        # valid insert
+        m = {
+            "record_type": DummyModel.collection(),
+            "name": "Cooper Gatlin",
+            "age": 25
+        }
+
+        store.write(m)
+        store.done()
+
+        self.assertEqual(db[DummyModel.collection()].count_documents({}), 1)
+
+    def test_failed_insert(self):
+        client = MongoClient(host='localhost', port=27017,
+                             username='dummy', password='password')
+
+        db = client["test"]
+
+        for collection in db.list_collection_names():
+            db[collection].drop()
+
+        store = mongodbstore.MongoDBStore('test', 'dummy', 'password',
+                                          'localhost', 27017,
+                                          models=[DummyModel])
+        # invalid insert
+        m_invalid = {
+            "record_type": DummyModel.collection(),
+            "name": "zz",
+            "age": 25
+        }
+        m_valid = DummyModel("Cooper Gatlin", {"age": 25}).marshal()
+
+        store.write(m_invalid)
+        store.write(m_valid)
+        store.done()
+
+        # Testing if atleast the valid record is inserted. This is enforced
+        # by the option ordered=False in insert_many, that tries to insert all
+        # documents unordered. Since mongo already validates all docsuments
+        # it makes sense to try to insert all, the failed ones will be rejected
+        # Check http://api.mongodb.com/python/current/api/pymongo/
+        # collection.html#pymongo.collection.Collection.insert_many
+        self.assertEqual(db[DummyModel.collection()].count_documents({}), 1)
+
+    def test_warning_insert(self):
+        client = MongoClient(host='localhost', port=27017,
+                             username='dummy', password='password')
+
+        db = client["test"]
+
+        for collection in db.list_collection_names():
+            db[collection].drop()
+
+        store = mongodbstore.MongoDBStore('test', 'dummy', 'password',
+                                          'localhost', 27017,
+                                          models=[DummyModel])
+        # valid insert
+        m = {
+            "record_type": DummyModel.collection(),
+            "name": "zz",
+            "age": 25
+        }
+
+        db.command({
+            "collMod": DummyModel.collection(),
+            "validationAction": "warn"
+        })
+
+        store.write(m)
+        store.done()
+
+        self.assertEqual(db[DummyModel.collection()].count_documents({}), 1)


### PR DESCRIPTION
This commit adds a `docker-compose.yml` file to spin up a mongoDB server and UI for automated
tests and inspection.

The docker file is configured to use the same credentials as the tests.
Use `docker-compose -f cloudmarker/test/data/docker-compose.yml up` to
run the stack.

Add follwing tests:
- happy path test
- valid insert
- invalid insert on schema validation
- insert with warning on schema validation