### PR TITLE
Do not run 'clean' target before running 'lint'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,8 @@ coverage: FORCE
 # (in diff format) that we need to make to fix the import statements.
 # Note that this independently invoked isort exits with exit code 0
 # regardless of whether it finds problems with import statements or not.
-lint: clean
-	. ./venv && isort --quiet --diff
+lint:
+	. ./venv && isort --quiet --diff --skip-glob "*/build/*"
 	. ./venv && pylama
 
 # The -M option for sphinx-apidoc puts the package documentation before

--- a/pylama.ini
+++ b/pylama.ini
@@ -1,6 +1,9 @@
 [pylama]
 linters = pycodestyle,pydocstyle,pyflakes,mccabe,pylint,isort
+skip = build/*
 ignore = D203,D213,D406,D407,C0103,W0511
+
+# The `skip` value ignores files created by `setup` module.
 
 # D203 1 blank line required before class docstring (found 0) [pydocstyle]
 # D213 Multi-line docstring summary should start at the second line [pydocstyle]


### PR DESCRIPTION
This change fixes an issue introduced in commit 1ee640a60173e06841e19058a9cea10d34db2a07 which we will call as the *faulty commit*. The faulty commit made the `lint` target depend on the `clean` target, so that the `clean` target is run before the `lint` target. That change was done so that `build/*` files (created by the invocation of `setup` module in `cloudmarker/test/test_setup.py`) were removed before the linters are run, otherwise the linters would detect problems in the `build` directory too.

While the faulty commit solved the problem described in the previous paragraph, it also introduced a new issue in Travis CI environment. Travis CI configuration in `.travis.yml` shows that after `make checks` is run, the `coveralls` command is run which uploads the test coverage results to Coveralls ( https://coveralls.io/ ). But when the `coveralls` command runs, the test coverage results no longer exist. The `checks` target invokes `lint` as a dependency which in turn invokes `clean` as a dependency and the `clean` target removes the test coverage results.

Due to this issue, no coverage results are available in Coveralls ever since that change was done. See https://coveralls.io/repos/242255/builds to confirm that there is no coverage data after build 104.

This change resolves this issue by undoing the change in that commit. Further, to resolve the original issue of preventing the linters from reporting errors in `build/*` directory, Pylama and isort are being invoked with `skip` and `--skip-glob` options, respectively, to skip files in the `build` directory.