### PR TITLE
Default MongoDBStore parameters and default mongodbstore config key

### DIFF
--- a/cloudmarker/stores/mongodbstore.py
+++ b/cloudmarker/stores/mongodbstore.py
@@ -11,8 +11,8 @@ _log = logging.getLogger(__name__)
 class MongoDBStore:
     """A plugin to store records on MongoDB."""
 
-    def __init__(self, db, username, password, host, port=27017,
-                 buffer_size=1000, **kwargs):
+    def __init__(self, host='localhost', port=27017, db='cloudmarker',
+                 username=None, password=None, buffer_size=1000, **kwargs):
         """Create an instance of :class:`MongoDBStore` plugin.
 
         It will use the default port for mongodb 27017 if not specified.
@@ -21,12 +21,12 @@ class MongoDBStore:
         negotiation.
 
         Arguments:
+            host (str): hostname for the DB server
+            port (int): port for mongoDB is listening
             db (str): name of the database
             username (str): username for the database
             password (str): password for username to authenticate with the db
-            host (str): hostname for the DB server
-            port (int): port for mongoDB is listening, defaults to 27017
-            buffer_size (int): max buffer before flushing to db
+            buffer_size (int): maximum number of records to buffer
             kwargs (dict): Additional args
                 * models - List of classes for validator and enforcement
                     requirements.

--- a/config.base.yaml
+++ b/config.base.yaml
@@ -5,6 +5,8 @@ clouds:
 stores:
   filestore:
     plugin: cloudmarker.stores.filestore.FileStore
+  mongodbstore:
+    plugin: cloudmarker.stores.mongodbstore.MongoDBStore
 
 checks:
   mockcheck:


### PR DESCRIPTION
Resolves #28.

#### Add defaults for all MongoDBStore parameters

This change adds sensible default values for all parameters for the `MongoDBStore` plugin. These default values would help new users as well as developers who are trying out `MongoDBStore` on a local system to run it with minimal configuration.

The defaults are chosen such that the plugin can connect to a locally running MongoDB that requires no authentication. The database name is set to `cloudmarker` by default. This is consistent with the default path of `/tmp/cloudmarker` in `FileStore`.

#### Add mongodbstore key in config.base.yaml

Provide a `mongodbstore` key in `config.base.yaml` that would create a MongoDBStore plugin object with its default parameters. This would allow users and developers to use this key readily in the user configuration (e.g., `config.yaml`) as long as they intend to connect to a locally running MongoDB that does not require authentication.

#### Minimal Sanity Check

Here are the steps for a minimal sanity check that MongoDB store is working fine:

 1. Install MongoDB and run it.

        brew install mongodb
        rm -rf db && mkdir db && mongod --dbpath db

 2. Add this configuration to `config.yaml` in the top-level directory of the project.

        audits:
          mockaudit:
            stores:
              - filestore
              - mongodbstore

 3. Run the project.

        python3 -m cloudmarker -f

 4. Finally, connect to MongoDB with a MongoDB client and query the inserted documents.

        mongo cloudmarker --quiet --eval "db.foo.find()"
        mongo cloudmarker --quiet --eval "db.bar.find()"

    Here is an example output:

        $ mongo cloudmarker --quiet --eval "db.foo.find()"
        { "_id" : ObjectId("5c593a2d6cb3e365d5acfcd1"), "record_num" : 0, "record_type" : "foo" }
        { "_id" : ObjectId("5c593a2d6cb3e365d5acfcd2"), "record_num" : 2, "record_type" : "foo" }
        { "_id" : ObjectId("5c593a2d6cb3e365d5acfcd3"), "record_num" : 4, "record_type" : "foo" }
        { "_id" : ObjectId("5c593a2d6cb3e365d5acfcd4"), "record_num" : 6, "record_type" : "foo" }
        { "_id" : ObjectId("5c593a2d6cb3e365d5acfcd5"), "record_num" : 8, "record_type" : "foo" }

        $ mongo cloudmarker --quiet --eval "db.bar.find()"
        { "_id" : ObjectId("5c593a2d6cb3e365d5acfcd6"), "record_num" : 1, "record_type" : "bar" }
        { "_id" : ObjectId("5c593a2d6cb3e365d5acfcd7"), "record_num" : 3, "record_type" : "bar" }
        { "_id" : ObjectId("5c593a2d6cb3e365d5acfcd8"), "record_num" : 5, "record_type" : "bar" }
        { "_id" : ObjectId("5c593a2d6cb3e365d5acfcd9"), "record_num" : 7, "record_type" : "bar" }
        { "_id" : ObjectId("5c593a2d6cb3e365d5acfcda"), "record_num" : 9, "record_type" : "bar" }
