### PR TITLE
Fix docstring indentation in MongoDBStore

### DIFF
--- a/cloudmarker/stores/mongodbstore.py
+++ b/cloudmarker/stores/mongodbstore.py
@@ -29,7 +29,7 @@ class MongoDBStore:
             buffer_size (int): maximum number of records to buffer
             kwargs (dict): Additional args
                 * models - List of classes for validator and enforcement
-                    requirements.
+                requirements.
         """
         self._client = MongoClient(
             host=host,


### PR DESCRIPTION
The commit fixes the following warning that occurs while running
`make docs`.

    cloudmarker/stores/mongodbstore.py:docstring of
    cloudmarker.stores.mongodbstore.MongoDBStore:24:
    WARNING: Unexpected indentation.