### PR TITLE
Handle cloud errors in AzureCloud

### DIFF
--- a/cloudmarker/clouds/azurecloud.py
+++ b/cloudmarker/clouds/azurecloud.py
@@ -13,6 +13,7 @@ from azure.mgmt.compute import ComputeManagementClient
 from azure.mgmt.network import NetworkManagementClient
 from azure.mgmt.resource import ResourceManagementClient, SubscriptionClient
 from azure.mgmt.storage import StorageManagementClient
+from msrestazure.azure_exceptions import CloudError
 
 _log = logging.getLogger(__name__)
 
@@ -120,12 +121,16 @@ def _get_doc(iterator, record_type, sub_id):
         dict: A document of type ``record_type``.
 
     """
-    for i, v in enumerate(iterator):
-        doc = v.as_dict()
-        doc['record_type'] = record_type
-        doc['sub_id'] = sub_id
+    try:
+        for i, v in enumerate(iterator):
+            doc = v.as_dict()
+            doc['record_type'] = record_type
+            doc['sub_id'] = sub_id
 
-        _log.info('Found document %s #%d; sub_id: %s; name: %s',
-                  record_type, i, sub_id, doc['name'])
+            _log.info('Found document %s #%d; sub_id: %s; name: %s',
+                      record_type, i, sub_id, doc['name'])
 
-        yield doc
+            yield doc
+    except CloudError as e:
+        _log.error('Failed to fetch details for %s; sub_id: %s; error: %s: %s',
+                   record_type, sub_id, type(e).__name__, e)


### PR DESCRIPTION
Some subscriptions in Azure could result in the following exception at line [123](https://github.com/cloudmarker/cloudmarker/pull/43/commits/aa82f0a272ff063c23ee019c52cb6e739dcf76c2#diff-4fb06491b278fdc6193c4b1e9b8d0284R123) in cloudmarker/clouds/azurecloud.py while iterating over the objects of any specified Azure provider.

```
msrestazure.azure_exceptions.CloudError: Azure Error: DisallowedOperation
Message: The current subscription type is not permitted to perform operations on any provider namespace. Please use a different subscription.
```

This commit aims to catch these exceptions and handle them gracefully by letting the code continue reading documents from other Azure subscriptions instead of exiting when any subscription throws the above exception.