### PR TITLE
Increase logging levels of root logger and adal-python

### DIFF
--- a/config.base.yaml
+++ b/config.base.yaml
@@ -58,12 +58,8 @@ logger:
       encoding: utf8
 
   loggers:
-    cloudmarker.workers:
-      level: DEBUG
-      handlers:
-      - console
-      - file_handler
-      propagate: 0
+    adal-python:
+      level: WARNING
 
   root:
     level: INFO

--- a/config.base.yaml
+++ b/config.base.yaml
@@ -66,10 +66,10 @@ logger:
       propagate: 0
 
   root:
-    level: DEBUG
+    level: INFO
     handlers:
-    - console
-    - file_handler
+      - console
+      - file_handler
 
 
 schedule: "00:00"


### PR DESCRIPTION
#### Increase logging level of root logger to INFO

Prior to this change, the logging level of the root logger was set to
DEBUG. This causes debug logs like the following to appear in the logs:

    DEBUG adal-python:121 - b4cf52ce-d62b-418c-b581-402845596e76 -
    Authority:Performing instance discovery: ...
    DEBUG adal-python:121 - b4cf52ce-d62b-418c-b581-402845596e76 -
    Authority:Performing static instance discovery
    DEBUG adal-python:121 - b4cf52ce-d62b-418c-b581-402845596e76 -
    Authority:Authority validated via static instance discovery

DEBUG logs are not necessary during normal functioning of the project.
They are useful only while troubleshooting. Therefore, in this change,
the logging level for the root logger has been raised to INFO.


#### Increase logging level of adal-python to WARNING

The INFO logs from adal-python are too verbose. They look like this:

    INFO adal-python:114 - 689fc9e5-2ed2-48e6-a36f-0a639a53a542 -
    TokenRequest:Getting token with client credentials.
    INFO adal-python:114 - 351e6e1b-f1e0-405f-b5d2-b669ca90940b -
    TokenRequest:Getting token with client credentials.
    INFO adal-python:114 - 2d08965e-0f8e-4150-b3f3-044a0b59c4c4 -
    TokenRequest:Getting token with client credentials.

These INFO logs are not useful from the perspective of this project.
Therefore, in order to improve the signal-to-noise ratio in the logs,
the logging level of adal-python has been raised to WARNING.
