### PR TITLE
Place closing bracket in its own line

### DIFF
--- a/cloudmarker/stores/filestore.py
+++ b/cloudmarker/stores/filestore.py
@@ -82,7 +82,7 @@ class FileStore:
             # End the JSON array by writing a closing bracket.
             tmp_file_path = os.path.join(self._path, worker_name) + '.tmp'
             with open(tmp_file_path, 'a') as f:
-                f.write(']\n')
+                f.write('\n]\n')
 
             # Rename the temporary file to a JSON file.
             json_file_path = os.path.join(self._path, worker_name) + '.json'


### PR DESCRIPTION
The opening bracket in the JSON files written by FileStore exists in its
own line, so the closing bracket is also placed in its own line for
the sake of symmetry.

Resolves: #47