### PR TITLE
Add FirewallRuleEvent plugin

### DIFF
--- a/cloudmarker/events/firewallruleevent.py
+++ b/cloudmarker/events/firewallruleevent.py
@@ -1,0 +1,145 @@
+"""Firewall rule event.
+
+This module defines the :class:`FirewallRuleEvent` class that identifies
+weak firewall rules. This plugin works on the firewall properties found
+in the ``com`` bucket of firewall rule records.
+"""
+
+
+import logging
+
+from cloudmarker import util
+
+_log = logging.getLogger(__name__)
+
+
+class FirewallRuleEvent:
+    """Firewall rule event plugin."""
+
+    def __init__(self, ports=None):
+        """Create an instance of :class:`FirewallRuleEvent` plugin.
+
+        Arguments:
+            ports (list): A list of strings that represent the ports to
+                be checked for insecure exposure to the Internet. If
+                ``None`` is specified or if unspecified, then this
+                plugin defaults to checking ports 22, 3389, 1433, 1521,
+                3306, and 5432 for insecure exposure.
+
+        """
+        if ports is None:
+            self._ports = {
+                22,    # SSH
+                3389,  # RDP
+                1433,  # Microsoft SQL Server
+                1521,  # Oracle DB
+                3306,  # MySQL
+                5432,  # Postgres
+            }
+        else:
+            self._ports = set(ports)
+
+    def eval(self, record):
+        """Evaluate firewall rules to check for insecurely exposed ports.
+
+        Arguments:
+            record (dict): A firewall rule record.
+
+        Yields:
+            dict: An event record representing an insecurely exposed port.
+
+        """
+        # If 'com' bucket is missing, we have a malformed record. Log a
+        # warning and ignore it.
+        com = record.get('com')
+        if com is None:
+            _log.warning('Firewall rule record is missing com key: %r',
+                         record)
+            return
+
+        # This plugin understands firewall rule records only, so ignore
+        # any other record types.
+        common_record_type = com.get('record_type')
+        if common_record_type != 'firewall_rule':
+            return
+
+        # Ignore disabled firewall rule.
+        if not com.get('enabled'):
+            return
+
+        # If the rule is not an ingress/inbound rule, ignore it.
+        if com.get('direction') != 'in':
+            return
+
+        # If the rule is not an allow rule, ignore it.
+        if com.get('access') != 'allow':
+            return
+
+        # If the rule is not a TCP port rule, ignore it.
+        if com.get('protocol') not in ('tcp', 'all'):
+            return
+
+        # If the rule does not expose ports to the entire Internet,
+        # ignore it.
+        if '0.0.0.0/0' not in com.get('source_addresses'):
+            return
+
+        # Find the set of ports in self._ports that are exposed by the
+        # firewall rule record.
+        port_ranges = com.get('destination_ports')
+        expanded_ports = util.expand_port_ranges(port_ranges)
+        exposed_ports = self._ports.intersection(expanded_ports)
+
+        # If there are no insecurely exposed ports, we do not need to
+        # generate an event.
+        if exposed_ports == set():
+            return
+
+        # Convert the set of ports to a sorted list of ports.
+        exposed_ports = sorted(list(exposed_ports))
+
+        # Human-friendly plain English description of the event along
+        # with a recommendation.
+        friendly_cloud_type = util.friendly_string(com.get('cloud_type'))
+        port_label = util.pluralize(len(exposed_ports), 'port')
+        friendly_exposed_ports = util.friendly_list(exposed_ports)
+        reference = com.get('reference')
+        description = (
+            '{} firewall rule {} exposes {} {} to the entire Internet.'
+            .format(friendly_cloud_type, reference, port_label,
+                    friendly_exposed_ports)
+        )
+        recommendation = (
+            'Check {} firewall rule {} and update rules to restrict '
+            'access to {} {}.'
+            .format(friendly_cloud_type, reference, port_label,
+                    friendly_exposed_ports)
+        )
+
+        event_record = {
+            # Preserve the extended properties from the firewall
+            # rule record because they provide useful context to
+            # locate the firewall rule that led to the event.
+            'ext': record.get('ext', {}),
+
+            'com': {
+                'cloud_type': com.get('cloud_type'),
+                'record_type': 'firewall_rule_event',
+                'exposed_ports': exposed_ports,
+                'reference': reference,
+                'description': description,
+                'recommendation': recommendation,
+            }
+        }
+
+        # Set the extended record type.
+        event_record['ext']['record_type'] = 'firewall_rule_event'
+
+        _log.info('Generating firewall_rule_event; %r', event_record)
+        yield event_record
+
+    def done(self):
+        """Perform cleanup work.
+
+        Currently, this method does nothing. This may change in future.
+        """

--- a/cloudmarker/test/test_firewallruleevent.py
+++ b/cloudmarker/test/test_firewallruleevent.py
@@ -1,0 +1,131 @@
+"""Tests for FirewallRuleEventTest plugin."""
+
+
+import copy
+import unittest
+
+from cloudmarker.events import firewallruleevent
+
+base_record = {
+    'com': {
+        'record_type': 'firewall_rule',
+        'enabled': True,
+        'direction': 'in',
+        'access': 'allow',
+        'protocol': 'tcp',
+        'source_addresses': ['0.0.0.0/0'],
+        'destination_ports': ['0-65535'],
+    }
+}
+
+
+class FirewallRuleEventTest(unittest.TestCase):
+    """Tests for FirewallRuleEventTest plugin."""
+
+    def test_tcp_all_exposed_ports(self):
+        record = copy.deepcopy(base_record)
+        plugin = firewallruleevent.FirewallRuleEvent(ports=[22, 3389])
+        events = list(plugin.eval(record))
+        self.assertEqual(events[0]['com']['exposed_ports'], [22, 3389])
+
+    def test_tcp_22_exposed_ports(self):
+        record = copy.deepcopy(base_record)
+        record['com']['destination_ports'] = ['22']
+        plugin = firewallruleevent.FirewallRuleEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events[0]['com']['exposed_ports'], [22])
+
+    def test_tcp_no_exposed_ports(self):
+        record = copy.deepcopy(base_record)
+        record['com']['destination_ports'] = ['8080']
+        plugin = firewallruleevent.FirewallRuleEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_com_missing(self):
+        record = {}
+        plugin = firewallruleevent.FirewallRuleEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_not_firewall_rule(self):
+        record = copy.deepcopy(base_record)
+        record['com']['record_type'] = 'foo'
+        plugin = firewallruleevent.FirewallRuleEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_not_enabled(self):
+        record = copy.deepcopy(base_record)
+        record['com']['enabled'] = False
+        plugin = firewallruleevent.FirewallRuleEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_direction_not_in(self):
+        record = copy.deepcopy(base_record)
+        record['com']['direction'] = 'out'
+        plugin = firewallruleevent.FirewallRuleEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_access_not_allow(self):
+        record = copy.deepcopy(base_record)
+        record['com']['access'] = 'deny'
+        plugin = firewallruleevent.FirewallRuleEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_protocol_not_tcp(self):
+        record = copy.deepcopy(base_record)
+        record['com']['protocol'] = 'udp'
+        plugin = firewallruleevent.FirewallRuleEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_protocol_all(self):
+        record = copy.deepcopy(base_record)
+        record['com']['protocol'] = 'all'
+        plugin = firewallruleevent.FirewallRuleEvent(ports=[22, 3389])
+        events = list(plugin.eval(record))
+        self.assertEqual(events[0]['com']['exposed_ports'], [22, 3389])
+
+    def test_source_addresses_not_entire_internet(self):
+        record = copy.deepcopy(base_record)
+        record['com']['source_addresses'] = ['4.0.0.0/8']
+        plugin = firewallruleevent.FirewallRuleEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_cloud_type(self):
+        record = copy.deepcopy(base_record)
+        record['com']['cloud_type'] = 'azure'
+        plugin = firewallruleevent.FirewallRuleEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events[0]['com']['cloud_type'], 'azure')
+
+    def test_record_type(self):
+        record = copy.deepcopy(base_record)
+        plugin = firewallruleevent.FirewallRuleEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events[0]['com']['record_type'],
+                         'firewall_rule_event')
+
+    def test_reference(self):
+        record = copy.deepcopy(base_record)
+        record['com']['reference'] = 'foo_ref'
+        plugin = firewallruleevent.FirewallRuleEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events[0]['com']['reference'], 'foo_ref')
+
+    def test_ext_properties_intact(self):
+        record = copy.deepcopy(base_record)
+        record['ext'] = {'a': 'apple', 'b': 'ball'}
+        plugin = firewallruleevent.FirewallRuleEvent()
+        events = list(plugin.eval(record))
+        expected_ext = {
+            'a': 'apple',
+            'b': 'ball',
+            'record_type': 'firewall_rule_event',
+        }
+        self.assertEqual(events[0]['ext'], expected_ext)

--- a/cloudmarker/test/test_util.py
+++ b/cloudmarker/test/test_util.py
@@ -110,3 +110,119 @@ class UtilTest(unittest.TestCase):
         c['a'].append(7)
         self.assertEqual(a, {'a': [1, 2, 3]})
         self.assertEqual(b, {'a': [4, 5, 6]})
+
+    def test_expand_port_ranges_empty_list(self):
+        ports = util.expand_port_ranges([])
+        self.assertEqual(ports, set())
+
+    def test_expand_port_ranges_single_port(self):
+        ports = util.expand_port_ranges(['80'])
+        self.assertEqual(ports, {80})
+
+    def test_expand_port_ranges_duplicate_ports(self):
+        ports = util.expand_port_ranges(['80', '80'])
+        self.assertEqual(ports, {80, 80})
+
+    def test_expand_port_ranges_duplicate_port_numbers(self):
+        ports = util.expand_port_ranges(['80', '80'])
+        self.assertEqual(ports, {80, 80})
+
+    def test_expand_port_ranges_single_range(self):
+        ports = util.expand_port_ranges(['80-89'])
+        self.assertEqual(ports, set(range(80, 90)))
+
+    def test_expand_port_ranges_overlapping_ranges(self):
+        ports = util.expand_port_ranges(['80-89', '85-99'])
+        self.assertEqual(ports, set(range(80, 100)))
+
+    def test_expand_port_ranges_all(self):
+        ports = util.expand_port_ranges(['0-65535'])
+        self.assertEqual(ports, set(range(0, 65536)))
+
+    def test_expand_port_ranges_empty_range(self):
+        ports = util.expand_port_ranges(['81-80'])
+        self.assertEqual(ports, set())
+
+    def test_expand_port_ranges_single_port_range(self):
+        ports = util.expand_port_ranges(['80-80'])
+        self.assertEqual(ports, {80})
+
+    def test_expand_port_ranges_invalid_port_range(self):
+        with self.assertRaises(util.PortRangeError):
+            util.expand_port_ranges(['8080a'])
+
+    def test_expand_port_ranges_invalid_port_in_port_range(self):
+        with self.assertRaises(util.PortRangeError):
+            util.expand_port_ranges(['8080a-8089'])
+
+    def test_friendly_string_present(self):
+        s = util.friendly_string('azure')
+        self.assertEqual(s, 'Azure')
+
+    def test_friendly_string_missing(self):
+        s = util.friendly_string('foo')
+        self.assertEqual(s, 'foo')
+
+    def test_friendly_list_zero_items(self):
+        s = util.friendly_list([])
+        self.assertEqual(s, 'none')
+
+    def test_friendly_list_one_item(self):
+        s = util.friendly_list(['apple'])
+        self.assertEqual(s, 'apple')
+
+    def test_friendly_list_two_items(self):
+        s = util.friendly_list(['apple', 'ball'])
+        self.assertEqual(s, 'apple and ball')
+
+    def test_friendly_list_three_items(self):
+        s = util.friendly_list(['apple', 'ball', 'cat'])
+        self.assertEqual(s, 'apple, ball, and cat')
+
+    def test_friendly_list_two_items_conjunction(self):
+        s = util.friendly_list(['apple', 'ball'], 'or')
+        self.assertEqual(s, 'apple or ball')
+
+    def test_friendly_list_three_items_conjunction(self):
+        s = util.friendly_list(['apple', 'ball', 'cat'], 'or')
+        self.assertEqual(s, 'apple, ball, or cat')
+
+    def test_pluralize_zero(self):
+        s = util.pluralize(0, 'apple')
+        self.assertEqual(s, 'apples')
+
+    def test_pluralize_one(self):
+        s = util.pluralize(1, 'apple')
+        self.assertEqual(s, 'apple')
+
+    def test_pluralize_two(self):
+        s = util.pluralize(2, 'apple')
+        self.assertEqual(s, 'apples')
+
+    def test_pluralize_zero_suffix(self):
+        s = util.pluralize(0, 'potato', 'es')
+        self.assertEqual(s, 'potatoes')
+
+    def test_pluralize_one_suffix(self):
+        s = util.pluralize(1, 'potato', 'es')
+        self.assertEqual(s, 'potato')
+
+    def test_pluralize_two_suffix(self):
+        s = util.pluralize(2, 'potato', 'es')
+        self.assertEqual(s, 'potatoes')
+
+    def test_pluralize_zero_suffixes(self):
+        s = util.pluralize(0, 'sky', 'y', 'ies')
+        self.assertEqual(s, 'skies')
+
+    def test_pluralize_one_suffixes(self):
+        s = util.pluralize(1, 'sky', 'y', 'ies')
+        self.assertEqual(s, 'sky')
+
+    def test_pluralize_two_suffixes(self):
+        s = util.pluralize(2, 'sky', 'y', 'ies')
+        self.assertEqual(s, 'skies')
+
+    def test_pluralize_two_surplus_suffix(self):
+        with self.assertRaises(util.PluralizeError):
+            util.pluralize(2, 'sky', 'y', 'ies', 'foo')

--- a/docs/api/cloudmarker.events.rst
+++ b/docs/api/cloudmarker.events.rst
@@ -17,6 +17,14 @@ cloudmarker.events.firewallevent module
     :undoc-members:
     :show-inheritance:
 
+cloudmarker.events.firewallruleevent module
+-------------------------------------------
+
+.. automodule:: cloudmarker.events.firewallruleevent
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 cloudmarker.events.mockevent module
 -----------------------------------
 

--- a/pylama.ini
+++ b/pylama.ini
@@ -22,6 +22,11 @@ ignore = E1101
 ignore = R0913
 # R0913 Too many arguments (7/5)
 
+[pylama:cloudmarker/events/firewallruleevent.py]
+ignore = R0911
+
+# R0911 Too many return statements (8/6) [pylint]
+
 [pylama:cloudmarker/alerts/emailalert.py]
 ignore = R0913,C0412
 


### PR DESCRIPTION
The FirewallRuleEvent plugin works on records of type `firewall_rule`. It looks at the `com` properties of such records to detect insecurely exposed ports and generates events.

Resolves: #69 