### PR TITLE
Remove emailalert from mockaudit in base config

### DIFF
--- a/config.base.yaml
+++ b/config.base.yaml
@@ -45,7 +45,6 @@ audits:
       - mockevent
     alerts:
       - filestore
-      - emailalert
 
 run:
   - mockaudit


### PR DESCRIPTION
Running sanity check on a fresh clone of Cloudmarker leads to this
error:

    $ python3 -m cloudmarker -f
    ...
    Traceback (most recent call last):
      File "/usr/lib/python3.5/multiprocessing/process.py", line 249, in _bootstrap
        self.run()
      File "/usr/lib/python3.5/multiprocessing/process.py", line 93, in run
        self._target(*self._args, **self._kwargs)
      File "cloudmarker/cloudmarker/workers.py", line 68, in store_worker
        store_plugin.done()
      File "cloudmarker/cloudmarker/alerts/emailalert.py", line 71, in done
        smtp_connection = smtplib.SMTP(host=self.host, port=self.port)
      File "/usr/lib/python3.5/smtplib.py", line 251, in __init__
        (code, msg) = self.connect(host, port)
      File "/usr/lib/python3.5/smtplib.py", line 335, in connect
        self.sock = self._get_socket(host, port, self.timeout)
      File "/usr/lib/python3.5/smtplib.py", line 306, in _get_socket
        self.source_address)
      File "/usr/lib/python3.5/socket.py", line 694, in create_connection
        for res in getaddrinfo(host, port, 0, SOCK_STREAM):
      File "/usr/lib/python3.5/socket.py", line 733, in getaddrinfo
        for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
    socket.gaierror: [Errno -2] Name or service not known

This error occurs because `emailalert` is enabled for `mockaudit` by
default in `config.base.yaml`. This change removes this from `mockaudit`
because there is no default configuration for the `EmailAlert` plugin
that would work well for all users. Also, `mockaudit` should run
successfully without any issues out of the box right after a fresh new
clone.

Resolves: #77 