### PR TITLE
Delete venv files after deleting environments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ deps: FORCE
 
 rmvenv: FORCE
 	rm -rf ~/.venv/cloudmarker
+	rm venv
 
 test: FORCE
 	# Test interactive Python examples in docstrings.
@@ -87,6 +88,7 @@ uservenv: FORCE
 
 rmuservenv: FORCE
 	rm -rf ~/.venv/cloudmarker-user
+	rm uservenv
 
 install:
 	@echo


### PR DESCRIPTION
Make targets that clean up virtual environments do not remove the
virtual environment files associated with them. This would result in
errors if `make deps` was run after the enviroment was cleaned up.