### PR TITLE
Fix ValueError for empty buffer in EsStore

### DIFF
--- a/cloudmarker/stores/esstore.py
+++ b/cloudmarker/stores/esstore.py
@@ -115,4 +115,5 @@ class EsStore:
 
     def done(self):
         """Flush pending records to Elasticsearch."""
-        self._flush()
+        if self._cur_buffer_size:
+            self._flush()


### PR DESCRIPTION
If the buffer is empty, the following exception is raised in the done
method of EsStore.

    ValueError: Empty value passed for a required argument 'body'.