### PR TITLE
Search for user configuration in popular locations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ cloudmarker.egg-info/
 dist/
 
 # Ignore local development files.
-config.yaml
+cloudmarker.yaml
 
 # Ignore Vim swap files.
 *.sw?

--- a/README.rst
+++ b/README.rst
@@ -35,12 +35,19 @@ Please follow these steps to setup the development environment:
 
     . ./venv
 
-5. In the top-level directory of the project, enter this command: ::
+5. In the top-level directory of the project, enter this command. ::
 
-    python3 -m cloudmarker
+    python3 -m cloudmarker -c -n
 
-   Right now, it generates mock data at ``/tmp/cloudmarker``. More
-   functionality will be added later.
+   The ``-c`` option without any arguments following it ensures that it
+   ignores local configuration files (if any) and runs Cloudmarker with
+   the built-in base configuration only. The built-in base configuration
+   makes it run a mock audit that generates mock data at
+   ``/tmp/cloudmarker``.
+
+   The ``-n`` option ensures that Cloudmarker ignores any schedule
+   configured in the built-in base configuration and runs the mock audit
+   right now.
 
 6. Run the unit tests, code coverage, linters, and document generator: ::
 

--- a/cloudmarker/__init__.py
+++ b/cloudmarker/__init__.py
@@ -1,5 +1,5 @@
 """Cloudmarker - Cloud security monitoring framework."""
 
 
-__version__ = '0.1.0.dev1'
+__version__ = '0.1.0.dev2'
 __author__ = 'Cloudmarker Authors and Contributors'

--- a/cloudmarker/baseconfig.py
+++ b/cloudmarker/baseconfig.py
@@ -1,3 +1,37 @@
+"""Base configuration.
+
+Attributes:
+    config_yaml (str): Base configuration as YAML code.
+    config_dict (dict): Base configuration as Python dictionary.
+
+Examples:
+    Here are a few examples that show how the values of these attributes
+    look::
+
+        >>> from cloudmarker import baseconfig
+        >>> print(baseconfig.config_yaml) # doctest: +ELLIPSIS
+        # Base configuration
+        clouds:
+          mockcloud:
+            plugin: cloudmarker.clouds.mockcloud.MockCloud
+        ...
+        >>> baseconfig.config_dict['clouds']
+        {'mockcloud': {'plugin': 'cloudmarker.clouds.mockcloud.MockCloud'}}
+        >>> baseconfig.config_dict['audits'] # doctest: +ELLIPSIS
+        {'mockaudit': {...}}
+        >>> baseconfig.config_dict['audits']['mockaudit']['clouds']
+        ['mockcloud']
+
+    .. Note that it is necessary to put the above example in a
+       reStructuredText literal code block created with the "::" marker
+       so that the doctest directive "# doctest: +ELLIPSIS" does not
+       appear in the rendered documentation.
+
+"""
+
+import yaml
+
+config_yaml = """# Base configuration
 clouds:
   mockcloud:
     plugin: cloudmarker.clouds.mockcloud.MockCloud
@@ -11,31 +45,14 @@ stores:
     plugin: cloudmarker.stores.mongodbstore.MongoDBStore
 
 events:
+  firewallruleevent:
+    plugin: cloudmarker.events.firewallevent.FirewallRuleEvent
   mockevent:
     plugin: cloudmarker.events.mockevent.MockEvent
-  firewallevent:
-    plugin: cloudmarker.evengts.firewallevent.FirewallEvent
 
 alerts:
   filestore:
     plugin: cloudmarker.stores.filestore.FileStore
-  slackalert:
-    plugin: cloudmarker.alerts.slackalert.SlackAlert
-    params:
-      bot_user_token: foo-bot-token
-      to:
-        - foo@example.com
-      text: foo
-  emailalert:
-    plugin: cloudmarker.alerts.emailalert.EmailAlert
-    params:
-      host: smtp.example.com
-      port: 25
-      sender: CloudMarker Alert <no-reply@example.com>
-      to:
-        - recipient@example.com
-      subject: Anomaly notification
-      body: default text
 
 audits:
   mockaudit:
@@ -52,8 +69,8 @@ run:
   - mockaudit
 
 logger:
-
   version: 1
+
   disable_existing_loggers: false
 
   formatters:
@@ -67,6 +84,7 @@ logger:
       level: DEBUG
       formatter: simple
       stream: ext://sys.stdout
+
     file_handler:
       class: logging.handlers.TimedRotatingFileHandler
       level: DEBUG
@@ -86,3 +104,7 @@ logger:
       - file_handler
 
 schedule: "00:00"
+"""
+
+
+config_dict = yaml.safe_load(config_yaml)

--- a/cloudmarker/test/test_main.py
+++ b/cloudmarker/test/test_main.py
@@ -8,7 +8,7 @@ from unittest import mock
 class MainTest(unittest.TestCase):
     """Tests for package execution."""
 
-    @mock.patch('sys.argv', ['cloudmarker', '-c', 'config.base.yaml', '-n'])
+    @mock.patch('sys.argv', ['cloudmarker', '-c', '-n'])
     def test_main(self):
         # Run cloudmarker package with only the default base
         # configuration and ensure that it runs without issues.

--- a/docs/api/cloudmarker.rst
+++ b/docs/api/cloudmarker.rst
@@ -19,6 +19,14 @@ Subpackages
 Submodules
 ----------
 
+cloudmarker.baseconfig module
+-----------------------------
+
+.. automodule:: cloudmarker.baseconfig
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 cloudmarker.manager module
 --------------------------
 


### PR DESCRIPTION
Since Cloudmarker is supposed to serve as a CLI tool that one can run
with `cloudmarker -n` as well as a service that one may run as
`cloudmarker`, it is convenient if Cloudmarker searches certain popular
paths where configuration files usually reside. This would prevent the
users or service unit definition from having to specify configuration
files as arguments to the `-c` or `--config` option.

With this change, it now looks for a configuration file at the following
locations in the order specified:

  - /etc/cloudmarker.yaml
  - ~/.cloudmarker.yaml
  - ~/cloudmarker.yaml
  - cloudmarker.yaml (i.e., in the current working directory)

The base configuration file (which was named `config.base.yaml`) earlier
has been removed from the file system. There is no counterpart for it
now on the file system. Instead the base configuration is now built into
the code in a new module named `baseconfig`. This has been done for the
following reasons:

  - Provide reasonable defaults as built-in. This is consistent with how
    other tools work, e.g., Vim, Bash, etc. ship with defaults and we
    write `~/.vimrc`, `~/.bashrc`, etc. only when we want to override
    these defaults.

  - The users were never supposed to edit `config.base.yaml` anyway. By
    removing it from the file system, the users do not have to worry
    about notions like base configuration and user configuration. They
    do not have to be careful about not editing the base configuration.
    The users can still refer to the base configuration if they wish to
    by entering `cloudmarker --print-base-config`.

Since multiple configuration paths are involved, the logging has been
improved to show what configuration paths are being looked for and which
configuration paths are being found.

Resolves: #89 