### PR TITLE
Remove EmailAlert configuration from base config

### DIFF
--- a/cloudmarker/baseconfig.py
+++ b/cloudmarker/baseconfig.py
@@ -53,19 +53,6 @@ events:
 alerts:
   filestore:
     plugin: cloudmarker.stores.filestore.FileStore
-  emailalert:
-    plugin: cloudmarker.alerts.emailalert.EmailAlert
-    params:
-      use_ssl: True
-      host: smtp.example.com
-      port: 25
-      sender: CloudMarker Alert <no-reply@example.com>
-      to:
-        - recipient@example.com
-      subject: Anomaly notification
-      body: default text
-      username: alice
-      password: alice@123
 
 audits:
   mockaudit:


### PR DESCRIPTION
The `baseconfig.py` module contains configuration for plugins that can
be used readily in a local development environment or in an environment
where the store or alert destinations are present locally. For these
plugins to be used readily, they should have sensible defaults.

Not all parameters of `EmailAlert` plugin can be defined with sensible
defaults. For example, there are no sensible defaults for `from_addr`
and `to_addrs`. Therefore, there should be no configuration for this in
`baseconfig.py`.