### PR TITLE
Do not log to file until fully configured; clean up log config

### DIFF
--- a/cloudmarker/baseconfig.py
+++ b/cloudmarker/baseconfig.py
@@ -84,7 +84,7 @@ logger:
       formatter: simple
       stream: ext://sys.stdout
 
-    file_handler:
+    file:
       class: logging.handlers.TimedRotatingFileHandler
       formatter: simple
       filename: logs/cloudmarker.log
@@ -99,7 +99,7 @@ logger:
     level: INFO
     handlers:
       - console
-      - file_handler
+      - file
 
 schedule: "00:00"
 """

--- a/cloudmarker/baseconfig.py
+++ b/cloudmarker/baseconfig.py
@@ -81,13 +81,11 @@ logger:
   handlers:
     console:
       class: logging.StreamHandler
-      level: DEBUG
       formatter: simple
       stream: ext://sys.stdout
 
     file_handler:
       class: logging.handlers.TimedRotatingFileHandler
-      level: DEBUG
       formatter: simple
       filename: logs/cloudmarker.log
       when: midnight

--- a/cloudmarker/manager.py
+++ b/cloudmarker/manager.py
@@ -10,6 +10,7 @@ subprocess.
 """
 
 
+import copy
 import logging.config
 import multiprocessing as mp
 import textwrap
@@ -29,7 +30,10 @@ def main():
     # Configure the logger as the first thing as per the base
     # configuration. We need this to be the first thing, so that
     # we can see the messages logged by util.load_config().
-    logging.config.dictConfig(baseconfig.config_dict['logger'])
+    log_config = copy.deepcopy(baseconfig.config_dict['logger'])
+    log_config['handlers'] = {'console': log_config['handlers']['console']}
+    log_config['root']['handlers'] = ['console']
+    logging.config.dictConfig(log_config)
     _log.info('Cloudmarker %s', cloudmarker.__version__)
 
     # Parse the command line arguments and handle the options that can
@@ -45,6 +49,7 @@ def main():
     # Then configure the logger once again to honour any logger
     # configuration defined in the user's configuration files.
     logging.config.dictConfig(config['logger'])
+    _log.info('Cloudmarker %s; configured', cloudmarker.__version__)
 
     # Finally, run the audits, either right now or as per a schedule,
     # depending on the command line options.


### PR DESCRIPTION
#### Rename file_handler to file in base log config

This change has been done to make the logging handler name consistent to
the one named `console`.

#### Remove redundant handler log levels in base config

A logging handler which does not have its logging level set processes
all log messages anyway. Therefore, there is no need to explicitly set
its logging level to DEBUG.

#### Do not log to file until fully configured

Prior to this change, we configure the logger with the full logger
configuration in `baseconfig.py` as soon as Cloudmarker starts. This is
a problem because it causes Cloudmarker to attempt logging to a file
path that may not exist.

Further, the default path is `logs/cloudmarker.log` but it is possible
that a user does not want any log files to be written under the current
directory. This is particularly a problem when, for example, Cloudmarker
is installed under `/usr` because this path is defined to be read-only
by [FHS 2.3].

The user cannot change the path of the log file for the first few log
messages via a configuration file, because the first few logs are
written even before the configuration files have been read. Therefore,
with this change, we ensure that we begin logging to a file only after
all configuration files have been read, so that the user has a chance to
specify which path to write the logs to.

To accomplish this change, we use the logger configuration in
`baseconfig.py` but we initially override the logger handlers to log to
console only, i.e., avoid logging to file.

[FHS 2.3]: http://refspecs.linuxfoundation.org/FHS_2.3/fhs-2.3.html

Resolves: #112
Resolves: #113
