### PR TITLE
Put all plugin configs under a key named 'plugins'

### DIFF
--- a/cloudmarker/baseconfig.py
+++ b/cloudmarker/baseconfig.py
@@ -11,12 +11,14 @@ Examples:
         >>> from cloudmarker import baseconfig
         >>> print(baseconfig.config_yaml) # doctest: +ELLIPSIS
         # Base configuration
-        clouds:
+        plugins:
           mockcloud:
             plugin: cloudmarker.clouds.mockcloud.MockCloud
         ...
-        >>> baseconfig.config_dict['clouds']
-        {'mockcloud': {'plugin': 'cloudmarker.clouds.mockcloud.MockCloud'}}
+        >>> baseconfig.config_dict['plugins']['mockcloud']
+        {'plugin': 'cloudmarker.clouds.mockcloud.MockCloud'}
+        >>> baseconfig.config_dict['plugins']['filestore']
+        {'plugin': 'cloudmarker.stores.filestore.FileStore'}
         >>> baseconfig.config_dict['audits'] # doctest: +ELLIPSIS
         {'mockaudit': {...}}
         >>> baseconfig.config_dict['audits']['mockaudit']['clouds']
@@ -32,27 +34,24 @@ Examples:
 import yaml
 
 config_yaml = """# Base configuration
-clouds:
+plugins:
   mockcloud:
     plugin: cloudmarker.clouds.mockcloud.MockCloud
 
-stores:
-  esstore:
-    plugin: cloudmarker.stores.esstore.EsStore
   filestore:
     plugin: cloudmarker.stores.filestore.FileStore
+
+  esstore:
+    plugin: cloudmarker.stores.esstore.EsStore
+
   mongodbstore:
     plugin: cloudmarker.stores.mongodbstore.MongoDBStore
 
-events:
   firewallruleevent:
-    plugin: cloudmarker.events.firewallevent.FirewallRuleEvent
+    plugin: cloudmarker.events.firewallruleevent.FirewallRuleEvent
+
   mockevent:
     plugin: cloudmarker.events.mockevent.MockEvent
-
-alerts:
-  filestore:
-    plugin: cloudmarker.stores.filestore.FileStore
 
 audits:
   mockaudit:

--- a/cloudmarker/manager.py
+++ b/cloudmarker/manager.py
@@ -137,7 +137,7 @@ class Audit:
             input_queue = mp.Queue()
             args = (
                 audit_name + '-' + name,
-                util.load_plugin(config['alerts'][name]),
+                util.load_plugin(config['plugins'][name]),
                 input_queue,
             )
             worker = mp.Process(target=workers.store_worker, args=args)
@@ -149,7 +149,7 @@ class Audit:
             input_queue = mp.Queue()
             args = (
                 audit_name + '-' + name,
-                util.load_plugin(config['events'][name]),
+                util.load_plugin(config['plugins'][name]),
                 input_queue,
                 self._alert_queues,
             )
@@ -162,7 +162,7 @@ class Audit:
             input_queue = mp.Queue()
             args = (
                 audit_name + '-' + name,
-                util.load_plugin(config['stores'][name]),
+                util.load_plugin(config['plugins'][name]),
                 input_queue,
             )
             worker = mp.Process(target=workers.store_worker, args=args)
@@ -173,7 +173,7 @@ class Audit:
         for name in audit_config['clouds']:
             args = (
                 audit_name + '-' + name,
-                util.load_plugin(config['clouds'][name]),
+                util.load_plugin(config['plugins'][name]),
                 self._store_queues + self._event_queues
             )
             worker = mp.Process(target=workers.cloud_worker, args=args)


### PR DESCRIPTION
Prior to this change, the various plugins were configured under separate
keys named `clouds`, `stores`, `events`, and `alerts`. This led to
duplicate plugin configs when the same store plugin is used as alert
plugin as well.

For example, in order to use `FileStore` and `SplunkHECStore` plugins
for both storing cloud records and event records, we need to duplicate
the configuration for them twice, once under `stores` and again under
`alerts`:

    stores:
      filestore:
        plugin: cloudmarker.stores.filestore.FileStore

      splunkstore:
        plugin: cloudmarker.stores.splunkhecstore.SplunkHECStore
        params:
          uri: https://localhost:8088/services/collector
          token: token123
          index_name: main
          ca_cert: false

    alerts:
      filestore:
        plugin: cloudmarker.stores.filestore.FileStore

      splunkstore:
        plugin: cloudmarker.stores.splunkhecstore.SplunkHECStore
        params:
          uri: https://localhost:8088/services/collector
          token: token123
          index_name: main
          ca_cert: false

    audits:
      mockaudit:
        stores:
          - filestore
          - splunkstore
        alerts:
          - filestore
          - splunkstore

With this change, all plugin configuration is placed under a single key
named `plugins` as shown in the following example:

    plugins:
      filestore:
        plugin: cloudmarker.stores.filestore.FileStore

      splunkstore:
        plugin: cloudmarker.stores.splunkhecstore.SplunkHECStore
        params:
          uri: https://localhost:8088/services/collector
          token: token123
          index_name: main
          ca_cert: false

    audits:
      mockaudit:
        stores:
          - filestore
          - splunkstore
        alerts:
          - filestore
          - splunkstore

Thus, there is no need to configure the same plugin twice as a store and
as an alert. If the same plugin can be used as both a store plugin and
as an alert plugin, it can be defined only once and reused as store as
well as alert.

Note: This pull request is rebased on PR #114.