### PR TITLE
Make SplunkHECStore logs detailed and handle empty list of records

### DIFF
--- a/cloudmarker/stores/splunkhecstore.py
+++ b/cloudmarker/stores/splunkhecstore.py
@@ -60,6 +60,11 @@ class SplunkHECStore:
         """Perform bulk insert of buffered records into Splunk."""
         buffer_len = len(self._buffer)
 
+        if buffer_len == 0:
+            _log.info('No pending records to index; URI: %s; index: %s',
+                      self._uri, self._index)
+            return
+
         _log.info('Indexing %d records; URI: %s; index: %s ...',
                   buffer_len, self._uri, self._index)
 

--- a/cloudmarker/stores/splunkhecstore.py
+++ b/cloudmarker/stores/splunkhecstore.py
@@ -11,13 +11,13 @@ _log = logging.getLogger(__name__)
 class SplunkHECStore:
     """SplunkHECStore plugin to index cloud data in Splunk using HEC token."""
 
-    def __init__(self, uri, token, index_name, ca_cert, buffer_size=1000):
+    def __init__(self, uri, token, index, ca_cert, buffer_size=1000):
         """Create an instance of :class:`SplunkHECStore` plugin.
 
         Arguments:
           uri (str): Splunk collector service URI.
           token (str): Splunk HEC token.
-          index_name (str): Splunk HEC token accessible index.
+          index (str): Splunk HEC token accessible index.
           ca_cert (str): Location of cetificate file to verify the identity
             of host in URI, or False to disable verification
           buffer_size (int): Maximum number of records to hold in
@@ -25,7 +25,7 @@ class SplunkHECStore:
         """
         self._uri = uri
         self._token = token
-        self._index = index_name
+        self._index = index
 
         self._ca_cert = ca_cert
         self._buffer_size = buffer_size

--- a/cloudmarker/test/test_splunkhecstore.py
+++ b/cloudmarker/test/test_splunkhecstore.py
@@ -43,12 +43,10 @@ class SplunkHECStoreTest(unittest.TestCase):
         splunk_store.write(mock_record)
         splunk_store.done()
 
-        mock_calls = mock_session().post.mock_calls
-
-        post_call_signature = mock.call(mock.ANY, headers=mock.ANY,
-                                        data=mock.ANY, verify=mock.ANY)
-        post_call_count = mock_calls.count(post_call_signature)
-        self.assertEqual(post_call_count, 2)
+        mock_session().post.assert_called_once_with(mock.ANY,
+                                                    headers=mock.ANY,
+                                                    data=mock.ANY,
+                                                    verify=mock.ANY)
 
     @mock.patch('requests.session')
     def test_post_failure_no_data_loss(self, mock_session):

--- a/cloudmarker/test/test_splunkhecstore.py
+++ b/cloudmarker/test/test_splunkhecstore.py
@@ -43,17 +43,12 @@ class SplunkHECStoreTest(unittest.TestCase):
         splunk_store.write(mock_record)
         splunk_store.done()
 
-        self.assertEqual(mock_session().post.mock_calls, [
-            mock.call(mock.ANY, headers=mock.ANY, data=mock.ANY,
-                      verify=mock.ANY),
+        mock_calls = mock_session().post.mock_calls
 
-            mock.call().json(),
-
-            mock.call(mock.ANY, headers=mock.ANY, data=mock.ANY,
-                      verify=mock.ANY),
-
-            mock.call().json(),
-        ])
+        post_call_signature = mock.call(mock.ANY, headers=mock.ANY,
+                                        data=mock.ANY, verify=mock.ANY)
+        post_call_count = mock_calls.count(post_call_signature)
+        self.assertEqual(post_call_count, 2)
 
     @mock.patch('requests.session')
     def test_post_failure_no_data_loss(self, mock_session):
@@ -68,7 +63,12 @@ class SplunkHECStoreTest(unittest.TestCase):
         splunk_store.write(mock_record)
         splunk_store.done()
 
-        self.assertEqual(len(mock_session().post.mock_calls), 2)
+        mock_calls = mock_session().post.mock_calls
+
+        post_call_signature = mock.call(mock.ANY, headers=mock.ANY,
+                                        data=mock.ANY, verify=mock.ANY)
+        post_call_count = mock_calls.count(post_call_signature)
+        self.assertEqual(post_call_count, 2)
 
     @mock.patch('requests.session')
     def test_post_fail_splunk_unable_to_index(self, mock_session):
@@ -83,7 +83,12 @@ class SplunkHECStoreTest(unittest.TestCase):
         splunk_store.write(mock_record)
         splunk_store.done()
 
-        self.assertEqual(len(mock_session().post.mock_calls), 4)
+        mock_calls = mock_session().post.mock_calls
+
+        post_call_signature = mock.call(mock.ANY, headers=mock.ANY,
+                                        data=mock.ANY, verify=mock.ANY)
+        post_call_count = mock_calls.count(post_call_signature)
+        self.assertEqual(post_call_count, 2)
 
     @mock.patch('requests.session')
     def test_post_fail_splunk_response_non_json(self, mock_session):


### PR DESCRIPTION
#### Make log messages detailed in SplunkHECStore

All log statements in SplunkHECStore have been updated so that their
message format is detailed and consistent throughout the module. The
following additional changes were made to achieve this:

  - The instance variable names have been shortened to keep the log
    statements compact.

  - To provide more detailed logs, we now access `response.text` where
    `response` is the object returned by `self._session.post`. This
    increases the number of mock calls on `mock_session().post` in the
    tests. Therefore, the tests have been updated to ignore any mock
    calls that are not `mock_session().post()`.


#### Rename 'index_name' to 'index' in SplunkHECStore

This change makes the renamed parameter name consistent with that of
EsStore and MongoDBStore. These other plugins do not use `_name` suffix
in the paramter names.


#### Do not post empty list of records to Splunk

Prior to this fix, when there are no records to index, SplunkHECStore
logs the following error:

    ERROR cloudmarker.stores.splunkhecstore:81 - Failed to index 0
    records; HTTP status code indicates error; URI:
    https://localhost:8088/services/collector; index: main; response
    status: 400; response content: {"text":"No data","code":5}

This error can be reproduced with a configuration like this where
`MockCloud` is configured to yield no records:

    plugins:
      mockcloud:
        plugin: cloudmarker.clouds.mockcloud.MockCloud
        params:
          record_count: 0

      splunkstore:
        plugin: cloudmarker.stores.splunkhecstore.SplunkHECStore
        params:
          uri: https://localhost:8088/services/collector
          token: token123
          index: main
          ca_cert: false

    audits:
      mockaudit:
        stores:
          - filestore
          - splunkstore
        alerts:
          - filestore
          - splunkstore

This fix ensures that when there are no records to index, no attempt is
made to post an empty list of records to Splunk.
