### PR TITLE
Set `origin_type` and `alert_worker` for events

### DIFF
--- a/cloudmarker/manager.py
+++ b/cloudmarker/manager.py
@@ -140,7 +140,7 @@ class Audit:
                 util.load_plugin(config['plugins'][name]),
                 input_queue,
             )
-            worker = mp.Process(target=workers.store_worker, args=args)
+            worker = mp.Process(target=workers.alert_worker, args=args)
             self._alert_workers.append(worker)
             self._alert_queues.append(input_queue)
 

--- a/cloudmarker/workers.py
+++ b/cloudmarker/workers.py
@@ -108,7 +108,7 @@ def event_worker(worker_name, event_plugin, input_queue, output_queues):
         for event_record in event_plugin.eval(record):
             event_record.setdefault('com', {})
             event_record['com']['origin_worker'] = worker_name
-            event_record['com']['origin_type'] = 'alert'
+            event_record['com']['origin_type'] = 'event'
             event_record['com']['event_worker'] = worker_name
             for q in output_queues:
                 q.put(event_record)


### PR DESCRIPTION
#### Set `origin_type` for events to `event`

(No description)


#### Populate `alert_worker` in `com` bucket

Prior to this change, the `com` bucket of events alerted with an alert
plugin looked like the following example:

```json
"com": {
  "record_type": "mock_event",
  "origin_worker": "mockaudit-mockevent",
  "origin_type": "event",
  "event_worker": "mockaudit-mockevent",
  "store_worker": "mockaudit-filestore"
}
```

Note that the last key in the example above is named as `store_worker`
although alerting is done by alert plugins. This was so because store
plugins and alert plugins implement the exact same interface via
duck-typing, so both types of plugins were worked on by a function named
`store_worker`.

While this makes sense for us (the developers), finding a `store_worker`
key in data written by an alert plugin could be confusing to a user.
Therefore, with this change, the `com` bucket of events alerted with an
alert plugin looks like this:

```json
"com": {
  "record_type": "mock_event",
  "origin_worker": "mockaudit-mockevent",
  "origin_type": "event",
  "event_worker": "mockaudit-mockevent",
  "alert_worker": "mockaudit-filestore"
}
```

To accomplish this behaviour, `workers.py` has been refactored by moving
the existing `store_worker` functionality to an internal `_write_worker`
function which can work on both store and alert plugins. It accepts an
additional parameter that tells it whether to populate `store_worker` or
`alert_worker` in the `com` bucket. Now there are two functions
`store_worker` and `alert_worker` which invoke with the `_write_worker`
function with the additional parameter to populate the `com` bucket
appropriately.