### PR TITLE
Make mock records similar to real records

### DIFF
--- a/cloudmarker/clouds/mockcloud.py
+++ b/cloudmarker/clouds/mockcloud.py
@@ -20,8 +20,8 @@ class MockCloud:
             >>> cloud = mockcloud.MockCloud()
             >>> for record in cloud.read():
             ...     print(record['raw']['data'],
-            ...           record['ext']['type'],
-            ...           record['com']['type'])
+            ...           record['ext']['record_type'],
+            ...           record['com']['record_type'])
             ...
             0 foo mock
             1 bar mock
@@ -83,11 +83,13 @@ class MockCloud:
                 },
 
                 'ext': {
-                    'type': self._record_types[i % n]
+                    'cloud_type': 'mock',
+                    'record_type': self._record_types[i % n]
                 },
 
                 'com': {
-                    'type': 'mock'
+                    'cloud_type': 'mock',
+                    'record_type': 'mock'
                 }
             }
 

--- a/cloudmarker/events/mockevent.py
+++ b/cloudmarker/events/mockevent.py
@@ -1,6 +1,9 @@
 """Mock event plugin for testing purpose."""
 
 
+from cloudmarker import util
+
+
 class MockEvent:
     """Mock event plugin for testing purpose."""
 
@@ -42,15 +45,23 @@ class MockEvent:
         """
         # If record data value is a multiple of self._n, generate an
         # event record.
-        if record.get('raw', {}).get('data', 1) % self._n == 0:
+        data = record.get('raw', {}).get('data', 1)
+        description = '{} is a multiple of {}.'.format(data, self._n)
+        recommendation = (
+            'Divide {} by {} and confirm that the remainder is 0.'
+            .format(data, self._n)
+        )
+        if data % self._n == 0:
             yield {
-                'ext': {
+                'ext': util.merge_dicts(record.get('ext', {}), {
                     'record_type': 'mock_event',
+                    'data': data,
                     'n': self._n,
-                    'cloud_record': record
-                },
+                }),
                 'com': {
-                    'record_type': 'mock_event'
+                    'record_type': 'mock_event',
+                    'description': description,
+                    'recommendation': recommendation,
                 }
             }
 

--- a/cloudmarker/util.py
+++ b/cloudmarker/util.py
@@ -78,8 +78,8 @@ def load_plugin(plugin_config):
         <class 'cloudmarker.clouds.mockcloud.MockCloud'>
         >>> for record in plugin.read():
         ...     print(record['raw']['data'],
-        ...           record['ext']['type'],
-        ...           record['com']['type'])
+        ...           record['ext']['record_type'],
+        ...           record['com']['record_type'])
         ...
         0 baz mock
         1 qux mock


### PR DESCRIPTION
The `cloud_type` and `record_type` fields have been added to `MockCloud`
records, so that they look similar to real cloud records from `AzCloud`
and `GCPCloud`.

Similarly, `description` and `recommendation` fields have been added to
`MockEvent` records, so that they look similar to `FirewallRuleEvent`
records.