### PR TITLE
Do not alter cloud record in FirewallRuleEvent

### DIFF
--- a/cloudmarker/events/firewallruleevent.py
+++ b/cloudmarker/events/firewallruleevent.py
@@ -120,7 +120,9 @@ class FirewallRuleEvent:
             # Preserve the extended properties from the firewall
             # rule record because they provide useful context to
             # locate the firewall rule that led to the event.
-            'ext': record.get('ext', {}),
+            'ext': util.merge_dicts(record.get('ext', {}), {
+                'record_type': 'firewall_rule_event'
+            }),
 
             'com': {
                 'cloud_type': com.get('cloud_type'),
@@ -131,9 +133,6 @@ class FirewallRuleEvent:
                 'recommendation': recommendation,
             }
         }
-
-        # Set the extended record type.
-        event_record['ext']['record_type'] = 'firewall_rule_event'
 
         _log.info('Generating firewall_rule_event; %r', event_record)
         yield event_record

--- a/cloudmarker/test/test_firewallruleevent.py
+++ b/cloudmarker/test/test_firewallruleevent.py
@@ -118,9 +118,9 @@ class FirewallRuleEventTest(unittest.TestCase):
         events = list(plugin.eval(record))
         self.assertEqual(events[0]['com']['reference'], 'foo_ref')
 
-    def test_ext_properties_intact(self):
+    def test_ext_copied_to_event(self):
         record = copy.deepcopy(base_record)
-        record['ext'] = {'a': 'apple', 'b': 'ball'}
+        record['ext'] = {'a': 'apple', 'b': 'ball', 'record_type': 'foo'}
         plugin = firewallruleevent.FirewallRuleEvent()
         events = list(plugin.eval(record))
         expected_ext = {
@@ -129,3 +129,16 @@ class FirewallRuleEventTest(unittest.TestCase):
             'record_type': 'firewall_rule_event',
         }
         self.assertEqual(events[0]['ext'], expected_ext)
+
+    def test_ext_unaltered_in_original_record(self):
+        record = copy.deepcopy(base_record)
+        record['ext'] = {'a': 'apple', 'b': 'ball', 'record_type': 'foo'}
+        plugin = firewallruleevent.FirewallRuleEvent()
+        expected_ext = {
+            'a': 'apple',
+            'b': 'ball',
+            'record_type': 'foo',
+        }
+        events = list(plugin.eval(record))
+        self.assertEqual(len(events), 1)
+        self.assertEqual(record['ext'], expected_ext)


### PR DESCRIPTION
Prior to this commit, `FirewallRuleEvent` plugin has a bug that caused
it to change the extended `record_type` property of the cloud record to
`firewall_rule_event`. This happened because this plugin first copied
the reference to cloud record's `ext` bucket to the new event record and
then set its `record_type` property in the `ext` bucket.

This fix performs a deepcopy of the `ext` bucket from the cloud record
to the event record to ensure that altering the `ext` bucket of the
event record does not alter that of the cloud record.