### PR TITLE
Add audit version to all records

### DIFF
--- a/cloudmarker/stores/filestore.py
+++ b/cloudmarker/stores/filestore.py
@@ -44,7 +44,7 @@ class FileStore:
             record (dict): Data to write to the file system.
 
         """
-        worker_name = record['com']['origin_worker']
+        worker_name = record.get('com', {}).get('origin_worker', 'no_worker')
 
         tmp_file_path = os.path.join(self._path, worker_name) + '.tmp'
         if worker_name not in self._worker_names:

--- a/cloudmarker/test/test_workers.py
+++ b/cloudmarker/test/test_workers.py
@@ -25,7 +25,8 @@ class WorkersTest(unittest.TestCase):
         out_q2 = mp.Queue()
 
         # Invoke the mock plugin with the worker.
-        workers.cloud_worker('foo', plugin, [out_q1, out_q2])
+        workers.cloud_worker('fooaudit', 'fooversion', 'foocloud',
+                             plugin, [out_q1, out_q2])
 
         # Test that the worker invoked the mock plugin's read() method
         # and finally invoked the mock plugin's done() method.
@@ -53,7 +54,32 @@ class WorkersTest(unittest.TestCase):
         in_q.put(None)
 
         # Invoke the mock plugin with the worker.
-        workers.store_worker('foo', plugin, in_q)
+        workers.store_worker('fooaudit', 'fooversion', 'foostore',
+                             plugin, in_q)
+
+        # Test that the worker invoked the mock plugin's write()
+        # method twice (once for each record) and finally invoked the
+        # mock plugin's done() method (for the None input).
+        expected_calls = [mock.call.write(mock.ANY),
+                          mock.call.write(mock.ANY),
+                          mock.call.done()]
+        self.assertEqual(plugin.mock_calls, expected_calls)
+
+    def test_alert_worker(self):
+        # Mock plugin.
+        plugin = mock.Mock()
+
+        # Test input queue for the mock plugin.
+        in_q = mp.Queue()
+
+        # Put two mock records and None in the test input queue.
+        in_q.put({'raw': {'data': 'record1'}})
+        in_q.put({'raw': {'data': 'record2'}})
+        in_q.put(None)
+
+        # Invoke the mock plugin with the worker.
+        workers.alert_worker('fooaudit', 'fooversion', 'fooalert',
+                             plugin, in_q)
 
         # Test that the worker invoked the mock plugin's write()
         # method twice (once for each record) and finally invoked the
@@ -85,7 +111,8 @@ class WorkersTest(unittest.TestCase):
         in_q.put(None)
 
         # Invoke the mock plugin with the worker.
-        workers.event_worker('foo', plugin, in_q, [out_q1, out_q2])
+        workers.event_worker('fooaudit', 'fooversion', 'fooevent',
+                             plugin, in_q, [out_q1, out_q2])
 
         # Test that the worker invoked the mock plugin's eval() method
         # twice (once for each input string record) and finally invoked

--- a/pylama.ini
+++ b/pylama.ini
@@ -17,6 +17,11 @@ ignore = R0902
 
 # R0902 Too many instance attributes (10/7) [pylint]
 
+[pylama:cloudmarker/workers.py]
+ignore = R0913
+
+# R0913 Too many arguments (6/5) [pylint]
+
 [pylama:cloudmarker/clouds/gcpcloud.py]
 ignore = E1101
 


### PR DESCRIPTION
This change adds a field named `audit_version` to every record. The
value of this field is a string that represents the time at which the
audits started. The value of this field is in `YYYYmmddHHMMSS` format,
e.g., `20190429180829`.

This version string is created only once at the beginning of a run of
all configured audits. The same version string is then used for all
audits. This way, all data obtained during a single run get the same
version string regardless of the actual start time of the individual
audits.

Additionally, this change adds two new record types.

  - `begin_audit`: A record with `record_type` as `begin_audit`
    indicates that a specific audit has started. The `audit_key` field
    in the `com` bucket shows which audit has started.

  - `end_audit`: A record of this type indicates that a specific audit
     has ended. The `audit_key` field in the `com` bucket shows which
     audit has ended.

Note that the same destination target may contain multiple `begin_audit`
record at the beginning of an audit. For example, if the same Splunk
instance is configured both as a store as well as an alert, then it
would receive one `begin_audit` record sent to the store worker and one
more sent to the alert worker. This holds good for `end_audit` record
too.

The audit version string in these records are useful in selecting or
querying the data obtained from the most recent run of an audit.

*--- end of commit message ---*

#### Splunk Query Examples

Here are some example Splunk queries that show how the `audit_version` field can be used.

#### Get a count of records pulled in each audit

```
index=main | stats count by com.audit_version
```


#### Version of the last completed audit

```
index=main com.record_type=end_audit | stats max(com.audit_version)
```


#### Select records from the last run of audits

```
index=main | join com.audit_version [search com.record_type=end_audit | stats max(com.audit_version) as com.audit_version]
```


#### Select event records from the last run of audits

```
index=main com.origin_type=event | join com.audit_version [search com.record_type = end_audit | stats max(com.audit_version) as com.audit_version]
```
