### PR TITLE
Handle empty destination_port_range gracefully

### DIFF
--- a/cloudmarker/clouds/azcloud.py
+++ b/cloudmarker/clouds/azcloud.py
@@ -355,7 +355,7 @@ def _get_normalized_firewall_destination_ports(security_rule):
     all_ports = []
 
     port = security_rule.get('destination_port_range')
-    if port is not None:
+    if port not in (None, ''):
         all_ports.append(port)
 
     ports = security_rule.get('destination_port_ranges')

--- a/cloudmarker/test/test_azcloud.py
+++ b/cloudmarker/test/test_azcloud.py
@@ -496,3 +496,61 @@ class AzCloudTest(unittest.TestCase):
 
         self.assertEqual(records[0]['com']['destination_ports'],
                          ['22', '3389', '8000-8080'])
+
+    def test_nsg_destination_port_range_empty(self):
+        mock_nsg_dict = {
+            'security_rules': [
+                {
+                    'destination_port_range': '',
+                }
+            ]
+        }
+
+        # We do not expect both 'destination_port_range' and
+        # 'destination_port_ranges' to be present in the same security
+        # rule but we are making sure here that even if they were to be
+        # present, we are able to handle it in a sensible manner.
+
+        mock_nsg = mock.Mock()
+        mock_nsg.as_dict.return_value = mock_nsg_dict
+
+        m = self._MockNetworkManagementClient
+        m().network_security_groups.list_all.return_value = [mock_nsg]
+
+        records = list(azcloud.AzCloud('', '', '').read())
+        records = [
+            r for r in records
+            if r['com']['record_type'] == 'firewall_rule'
+        ]
+
+        self.assertEqual(records[0]['com']['destination_ports'], [])
+
+    def test_nsg_destination_port_range_empty_and_port_ranges(self):
+        mock_nsg_dict = {
+            'security_rules': [
+                {
+                    'destination_port_range': '',
+                    'destination_port_ranges': ['3389', '8000-8080'],
+                }
+            ]
+        }
+
+        # We do not expect both 'destination_port_range' and
+        # 'destination_port_ranges' to be present in the same security
+        # rule but we are making sure here that even if they were to be
+        # present, we are able to handle it in a sensible manner.
+
+        mock_nsg = mock.Mock()
+        mock_nsg.as_dict.return_value = mock_nsg_dict
+
+        m = self._MockNetworkManagementClient
+        m().network_security_groups.list_all.return_value = [mock_nsg]
+
+        records = list(azcloud.AzCloud('', '', '').read())
+        records = [
+            r for r in records
+            if r['com']['record_type'] == 'firewall_rule'
+        ]
+
+        self.assertEqual(records[0]['com']['destination_ports'],
+                         ['3389', '8000-8080'])

--- a/cloudmarker/test/test_util.py
+++ b/cloudmarker/test/test_util.py
@@ -187,12 +187,12 @@ class UtilTest(unittest.TestCase):
         self.assertEqual(ports, {80})
 
     def test_expand_port_ranges_invalid_port_range(self):
-        with self.assertRaises(util.PortRangeError):
-            util.expand_port_ranges(['8080a'])
+        ports = util.expand_port_ranges(['8080', '8081a', '8082'])
+        self.assertEqual(ports, {8080, 8082})
 
     def test_expand_port_ranges_invalid_port_in_port_range(self):
-        with self.assertRaises(util.PortRangeError):
-            util.expand_port_ranges(['8080a-8089'])
+        ports = util.expand_port_ranges(['7070-7075', '808a-8085'])
+        self.assertEqual(ports, {7070, 7071, 7072, 7073, 7074, 7075})
 
     def test_friendly_string_present(self):
         s = util.friendly_string('azure')

--- a/cloudmarker/util.py
+++ b/cloudmarker/util.py
@@ -280,16 +280,14 @@ def expand_port_ranges(port_ranges):
         >>> print(ports == set())
         True
 
-        If the port range is invalid, :class:`PortRangeError` is raised.
+        If an invalid port range is found, it is ignored.
 
-        >>> util.expand_port_ranges(['8080a'])
-        Traceback (most recent call last):
-            ...
-        cloudmarker.util.PortRangeError: Invalid port range: 8080a
-        >>> util.expand_port_ranges(['8080a-8085'])
-        Traceback (most recent call last):
-            ...
-        cloudmarker.util.PortRangeError: Invalid port in port range: 8080a-8085
+        >>> ports = util.expand_port_ranges(['8080', '8081a', '8082'])
+        >>> print(ports == {8080, 8082})
+        True
+        >>> ports = util.expand_port_ranges(['7070-7075', '8080a-8085'])
+        >>> print(ports == {7070, 7071, 7072, 7073, 7074, 7075})
+        True
 
     Arguments:
         port_ranges (list): A list of strings where each string is a
@@ -313,15 +311,13 @@ def expand_port_ranges(port_ranges):
 
         # Otherwise, it must look like a port range, e.g., '1024-9999'.
         if '-' not in port_range:
-            raise PortRangeError('Invalid port range: {}'
-                                 .format(port_range))
+            continue
 
         # If it looks like a port range, it must be two numbers
         # with a hyphen between them.
         start_port, end_port = port_range.split('-', 1)
         if not start_port.isdigit() or not end_port.isdigit():
-            raise PortRangeError('Invalid port in port range: {}'
-                                 .format(port_range))
+            continue
 
         # Add the port numbers in the port range to the result set.
         expanded_ports = range(int(start_port), int(end_port) + 1)
@@ -587,10 +583,6 @@ def send_email(from_addr, to_addrs, subject, content,
 
 class PluginError(Exception):
     """Represents an error while loading a plugin."""
-
-
-class PortRangeError(Exception):
-    """Represents an error in parsing a port range."""
 
 
 class PluralizeError(Exception):


### PR DESCRIPTION
#### Ignore invalid port range in firewall rules

Instead of raising an error when an invalid port range is found in
firewall rules, ignore it silently. Here are the reasons behind this
decision:

  - During actual usage of this project, An Azure NSG record contained a
    security rule of the following form:

        {
            ...
            "source_address_prefix": "VirtualNetwork",
            "source_port_range": "*",
            "source_address_prefixes": [],
            ...
            "destination_address_prefixes": [],
            "destination_port_ranges": [
              "5601",
              "8080",
              "6380",
              "3000"
            ],
            "destination_address_prefix": "",
            "priority": 1004,
            "description": "Allow virtual-network traffic to services",
            "destination_port_range": "",
            ...
        }

    The empty string in `destination_address_prefix` field leads to the
    creation of a `firewall_rule` record of the following form:

        {
          ...
          "source_addresses": [
            "VirtualNetwork"
          ],
          ...
          "protocol": "all",
          "enabled": true,
          ...
          "destination_ports": [
            "",
            "5601",
            "8080",
            "6380",
            "3000"
          ],
          ...
        }

    The empty string was recognized as an invalid port range and an
    error was raised. Raising an error in this case crashes the
    FirewallRuleEvent plugin. Ignoring such invalid port ranges would
    allow the plugin to examine the other port ranges in the
    `firewall_rule` record.

  - If we find an invalid port range in the data, there is not much we
    can do about it, so instead of raising an error, we just continue to
    work on the remaining port numbers in order to detect security
    issues in them.

#### Handle empty destination_port_range gracefully

See previous commit message for an example of an example of an Azure
security rule that contains both `destination_port_range` and
`destination_port_ranges` fields in the same record with the value of
the former as an empty string.

Since an empty string for this field indicates a missing port range,
this change ensures that we ignore it.