### PR TITLE
Fix 'About' field in email notification for audits

### DIFF
--- a/cloudmarker/manager.py
+++ b/cloudmarker/manager.py
@@ -71,7 +71,7 @@ def _run(config):
         config (dict): Configuration dictionary.
     """
     start_time = time.localtime()
-    _send_email(config.get('email'), 'run', start_time)
+    _send_email(config.get('email'), 'all audits', start_time)
 
     # Create an audit object for each audit configured to be run.
     audit_version = time.strftime('%Y%m%d%H%M%S', time.gmtime())
@@ -88,7 +88,7 @@ def _run(config):
         audit.join()
 
     end_time = time.localtime()
-    _send_email(config.get('email'), 'run', start_time, end_time)
+    _send_email(config.get('email'), 'all audits', start_time, end_time)
 
 
 class Audit:
@@ -192,7 +192,8 @@ class Audit:
 
     def start(self):
         """Start audit by starting all workers."""
-        _send_email(self._config.get('email'), 'audit', self._start_time)
+        _send_email(self._config.get('email'), self._audit_key,
+                    self._start_time)
 
         begin_record = {'com': {'record_type': 'begin_audit'}}
 


### PR DESCRIPTION
This commit makes two fixes for the 'About' field in email
notifications:

  - The value of the 'About' field has been changed from 'run' to 'all
    audits' when the email notification is about all audits. This is
    clearer to understand than 'run'.

  - The audit start notification had the value of 'About' field as
    'audit' whereas that of the audit end notification had the audit key
    as specified in the configuration. This change ensures that the
    former value is also the audit key specified in the configuration.