### PR TITLE
Update logger format, filename, and backupCount

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,6 @@ deps: FORCE
 	touch venv
 	. ./venv && pip3 install -r requirements.txt
 	. ./venv && pip3 install -r dev-requirements.txt
-	mkdir -p logs
 
 rmvenv: FORCE
 	rm -rf ~/.venv/cloudmarker

--- a/cloudmarker/baseconfig.py
+++ b/cloudmarker/baseconfig.py
@@ -74,7 +74,9 @@ logger:
 
   formatters:
     simple:
-      format: "%(asctime)s %(levelname)s %(name)s:%(lineno)d - %(message)s"
+      format: >-
+          %(asctime)s [%(process)s] %(levelname)s
+          %(name)s:%(lineno)d - %(message)s
       datefmt: "%Y-%m-%d %H:%M:%S"
 
   handlers:
@@ -86,9 +88,10 @@ logger:
     file:
       class: logging.handlers.TimedRotatingFileHandler
       formatter: simple
-      filename: logs/cloudmarker.log
+      filename: /tmp/cloudmarker.log
       when: midnight
       encoding: utf8
+      backupCount: 5
 
   loggers:
     adal-python:


### PR DESCRIPTION
The log format now includes the process ID (PID). This is useful in
troubleshooting when a worker process crashes. Usually, when a worker
process crashes and the main process is still alive, the worker process
appears as `<defunct>` in the `ps` output. So comparing the PID of the
defunct process with the PIDs in the logs help us to understand which
process crashed.

The default `filename` as `logs/cloudmarker.log` has always required a
`mkdir -p logs` hack in `Makefile`. In this change, we are updating this
path to `/tmp/cloudmarker.log`, so that we no longer need this hack.
This will also ensure that anyone installing the project with `pip` for
the first time can run the mock plugins without any issues without
having to follow any additional steps.

Further, `backupCount` is set to `5`. This is useful during live usage
because the log files can be large when large clouds are audited. This
setting ensures that the log files do not fill up all the disk space. A
maximum of only 5 most recent backup log files are kept by default and
the older ones are deleted.
