### PR TITLE
Use YYYYmmdd_HHMMSS format for audit version

### DIFF
--- a/cloudmarker/manager.py
+++ b/cloudmarker/manager.py
@@ -74,7 +74,7 @@ def _run(config):
     _send_email(config.get('email'), 'all audits', start_time)
 
     # Create an audit object for each audit configured to be run.
-    audit_version = time.strftime('%Y%m%d%H%M%S', time.gmtime())
+    audit_version = time.strftime('%Y%m%d_%H%M%S', time.gmtime())
     audits = []
     for audit_key in config['run']:
         audits.append(Audit(audit_key, audit_version, config))


### PR DESCRIPTION
The earlier format was `YYYYmmddHHMMSS`. A resulting audit version used to
look like this for example: `20190411112030`.

The new format is `YYYYmmdd_HHMMSS`. The same audit version would look
like this now: `20190411_112030`. The new version is much easier to read
due to the underscore separating the date from the time.