### PR TITLE
Handle CloudError while iterating on VMs in AzVM

### DIFF
--- a/pylama.ini
+++ b/pylama.ini
@@ -77,4 +77,3 @@ ignore = R0201
 ignore = R0201
 
 # R0201 Method could be a function [pylint]
-


### PR DESCRIPTION
The `CloudError` exception may be raised while iterating on the virtual
machines iterator in this line of code:

    for vm_index, vm in enumerate(virtual_machines_iter):

An example of such an error is:

        msrestazure.azure_exceptions.CloudError: Azure Error:
        DisallowedOperation
        Message: The current subscription type is not permitted to
        perform operations on any provider namespace. Please use a
        different subscription.

This is currently correctly handled in `AzCloud` because `AzCloud`
iterates on each resource iterator inside a `try` block in its
`_get_record()` function. A similar approach is used in this fix to
resolve this issue.
