### PR TITLE
Add empty query to SVG URLs for uniform rendering

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,23 +3,23 @@ Cloudmarker
 
 Cloudmarker is a cloud monitoring tool and framework.
 
-.. image:: https://img.shields.io/badge/view-tutorial-blue.svg
-    :target: https://cloudmarker.readthedocs.io/en/latest/tutorial.html
+.. image:: https://img.shields.io/badge/read-tutorial-blue.svg?
+   :target: https://cloudmarker.readthedocs.io/en/latest/tutorial.html
 
-.. image:: https://img.shields.io/pypi/v/cloudmarker.svg
+.. image:: https://img.shields.io/pypi/v/cloudmarker.svg?
    :target: https://pypi.org/project/cloudmarker/
 
-.. image:: https://img.shields.io/badge/license-MIT-blue.svg
+.. image:: https://img.shields.io/badge/license-MIT-blue.svg?
    :target: https://github.com/cloudmarker/cloudmarker/blob/master/LICENSE.rst
 
 .. image:: https://travis-ci.com/cloudmarker/cloudmarker.svg?branch=master
-    :target: https://travis-ci.com/cloudmarker/cloudmarker
+   :target: https://travis-ci.com/cloudmarker/cloudmarker
 
 .. image:: https://readthedocs.org/projects/cloudmarker/badge/?version=latest
-    :target: https://cloudmarker.readthedocs.io/en/latest/?badge=latest
+   :target: https://cloudmarker.readthedocs.io/en/latest/?badge=latest
 
 .. image:: https://coveralls.io/repos/github/cloudmarker/cloudmarker/badge.svg?branch=master
-    :target: https://coveralls.io/github/cloudmarker/cloudmarker?branch=master
+   :target: https://coveralls.io/github/cloudmarker/cloudmarker?branch=master
 
 Contents
 --------


### PR DESCRIPTION
reStructuredText rendering for SVG images with target links is usually
not uniform across all renderers. For example, `rst2html.py` renders
SVGs with `<object>` tags. GitHub puts a linebreak in the HTML code
before the closing `</a>` tags. Adding a question mark (i.e., an empty
query string) appears to resolve this issue.
