### PR TITLE
Check only vm_instance_view data in disk plugins

### DIFF
--- a/cloudmarker/events/azvmosdiskencryptionevent.py
+++ b/cloudmarker/events/azvmosdiskencryptionevent.py
@@ -31,32 +31,21 @@ class AzVMOSDiskEncryptionEvent:
             of an Azure virtual machine
 
         """
-        # If 'com' bucket is missing, we have a malformed record. Log a
-        # warning and ignore it.
-        com = record.get('com')
-        if com is None:
-            _log.warning('Virtual machine record is missing \'com\' key: %r',
-                         record)
-            return
-
-        # This plugin understands compute rule records only,
-        # so ignore  any other record types.
-        common_record_type = com.get('record_type')
-
-        if common_record_type != 'compute':
-            return
-
-        # If 'ext' bucket is missing, we have a malformed record. Log a
-        # warning and ignore it.
         ext = record.get('ext')
         if ext is None:
-            _log.warning('Virtual machine record is missing \'ext\' key: %r',
-                         record)
             return
-        os_disk_encrypted = ext.get('os_disk_encrypted')
 
+        if ext.get('record_type') != 'vm_instance_view':
+            return
+
+        os_disk_encrypted = ext.get('os_disk_encrypted')
         if os_disk_encrypted:
             return
+
+        com = record.get('com')
+        if com is None:
+            return
+
         if com.get('cloud_type') == 'azure':
             yield from _get_azure_vm_os_disk_encryption_event(
                 com, ext, record.get('raw'))

--- a/cloudmarker/test/test_azvmdatadiskencryptionevent.py
+++ b/cloudmarker/test/test_azvmdatadiskencryptionevent.py
@@ -9,11 +9,11 @@ from cloudmarker.events import azvmdatadiskencryptionevent
 
 base_record = {
     'ext':  {
+        'record_type': 'vm_instance_view',
         'all_data_disks_encrypted':  True
     },
     'com':  {
-        'cloud_type':  'azure',
-        'record_type':  'compute'
+        'cloud_type':  'azure'
     }
 }
 

--- a/cloudmarker/test/test_azvmosdiskencryptionevent.py
+++ b/cloudmarker/test/test_azvmosdiskencryptionevent.py
@@ -8,11 +8,11 @@ from cloudmarker.events import azvmosdiskencryptionevent
 
 base_record = {
     'ext':  {
+        'record_type': 'vm_instance_view',
         'os_disk_encrypted':  True
     },
     'com':  {
-        'cloud_type':  'azure',
-        'record_type':  'compute'
+        'cloud_type':  'azure'
     }
 }
 


### PR DESCRIPTION
The current implementations of `AzVMOSDiskEncryptionEvent` and
`AzVMDataDiskEncryptionEvent` plugins generate events for VM records
obtained by `AzCloud` as well. This is a problem when both `AzCloud` and
`AzVM` belong to the same audit definition. Here is an example minimal
config that reproduces this issue:

    plugins:
      myazcloud:
        plugin: cloudmarker.clouds.azcloud.AzCloud
        params:
          tenant:
          client:
          secret:

      myazvm:
        plugin: cloudmarker.clouds.azvm.AzVM
        params:
          tenant:
          client:
          secret:

    audits:
      myazaudit:
        clouds:
          - myazcloud
          - myazvm
        stores:
          - filestore
        events:
          - firewallruleevent
          - azvmosdiskencryptionevent
          - azvmdatadiskencryptionevent
        alerts:
          - filestore
    run:
      - myazaudit

Assuming there is only one VM in the cloud, `AzVMOSDiskEncryptionEvent`
would generate two events, one for the `virtual_machine` record generated by
`AzCloud` and one more for the `vm_instance_view` record generated by `AzVM`.

Since these two plugins work only on `vm_instance_view` records (i.e.,
extended record type is `vm_instance_view`), it should ignore any other
extended record types. This change implements this.

Further, while implementing this change, I realized that it would be
better to not log warning messages for missing `com` and `ext` buckets.
One of the design goals of this project has been to let users write
their own plugins in which they are free to choose their record format.
If their records do not have `com` and `ext` buckets but these plugins
are configured to receive them, then these plugins should silently
ignore any records these do not care about instead of logging a warning
message for every record that does not meet these plugins' expected
format.