### PR TITLE
Use processes and threads in Azure cloud plugins

### DIFF
--- a/cloudmarker/baseconfig.py
+++ b/cloudmarker/baseconfig.py
@@ -63,8 +63,8 @@ logger:
   formatters:
     simple:
       format: >-
-          %(asctime)s [%(process)s] %(levelname)s
-          %(name)s:%(lineno)d - %(message)s
+          %(asctime)s [%(process)s] [%(processName)s] [%(threadName)s]
+          %(levelname)s %(name)s:%(lineno)d - %(message)s
       datefmt: "%Y-%m-%d %H:%M:%S"
 
   handlers:

--- a/cloudmarker/clouds/azvm.py
+++ b/cloudmarker/clouds/azvm.py
@@ -11,9 +11,8 @@ from azure.common.credentials import ServicePrincipalCredentials
 from azure.mgmt.compute import ComputeManagementClient
 from azure.mgmt.resource import SubscriptionClient
 from msrestazure import tools
-from msrestazure.azure_exceptions import CloudError
 
-from cloudmarker import util
+from cloudmarker import ioworkers, util
 
 _log = logging.getLogger(__name__)
 
@@ -21,7 +20,8 @@ _log = logging.getLogger(__name__)
 class AzVM:
     """Azure Virtual Machine plugin."""
 
-    def __init__(self, tenant, client, secret, _max_subs=0, _max_recs=0):
+    def __init__(self, tenant, client, secret, processes=4, threads=30,
+                 _max_subs=0, _max_recs=0):
         """Create an instance of :class:`AzVM` plugin.
 
          Note: The ``_max_subs`` and ``_max_recs`` arguments should be
@@ -43,8 +43,13 @@ class AzVM:
             client_id=client,
             secret=secret,
         )
+        self._tenant = tenant
+        self._processes = processes
+        self._threads = threads
         self._max_subs = _max_subs
         self._max_recs = _max_recs
+        _log.info('Initialized; tenant: %s; processes: %s; threads: %s',
+                  self._tenant, self._processes, self._threads)
 
     def read(self):
         """Return an Azure virtual machine record.
@@ -53,99 +58,159 @@ class AzVM:
             dict: An Azure virtual machine record.
 
         """
-        # pylint: disable=R0914
-        subscription_client = SubscriptionClient(self._credentials)
-        for i, sub in enumerate(subscription_client.subscriptions.list()):
-            subscription_id = str(sub.subscription_id)
-            _log.info('Found subscription #%d; subscription_id: %s; '
-                      'display_name: %s',
-                      i, subscription_id, sub.display_name)
+        yield from ioworkers.run(self._get_tenant_vms,
+                                 self._get_vm_instance_views,
+                                 self._processes, self._threads,
+                                 __name__)
 
-            # Initialize Azure clients for the current subscription.
+    def _get_tenant_vms(self):
+        """Get VMs from all subscriptions in a tenant.
+
+        The yielded tuples when unpacked would become arguments for
+        :meth:`_get_vm_instance_views`. Each such tuple represents a
+        single unit of work that :meth:`_get_vm_instance_views` can work
+        on independently in its own worker thread.
+
+        Yields:
+            tuple: A tuple which when unpacked forms valid arguments for
+                :meth:`_get_vm_instance_views`.
+
+        """
+        try:
+            tenant = self._tenant
             creds = self._credentials
-            compute_client = ComputeManagementClient(creds, subscription_id)
+            sub_client = SubscriptionClient(creds)
+            sub_list = sub_client.subscriptions.list()
 
-            yield from _get_record(compute_client, subscription_id,
-                                   self._max_recs)
+            for sub_index, sub in enumerate(sub_list):
+                sub = sub.as_dict()
+                _log.info('Found %s', util.outline_az_sub(sub_index,
+                                                          sub, tenant))
 
-            # Break after pulling data for self._max_subs number of
-            # subscriptions. Note that if self._max_subs is 0 or less,
-            # then the following condition never evaluates to True.
-            if i + 1 == self._max_subs:
-                _log.info('Ending subscriptions fetch due to '
-                          '_max_subs: %d', self._max_subs)
-                break
+                yield from self._get_subscription_vms(sub_index, sub)
+                # Break after pulling data for self._max_subs number of
+                # subscriptions. Note that if self._max_subs is 0 or less,
+                # then the following condition never evaluates to True.
+                if sub_index + 1 == self._max_subs:
+                    _log.info('Stopping subscriptions fetch due to '
+                              '_max_subs: %d; tenant: %s', self._max_subs,
+                              tenant)
+                    break
+
+        except Exception as e:
+            _log.error('Failed to fetch subscriptions; %s; error: %s: %s',
+                       util.outline_az_sub(sub_index, sub, tenant),
+                       type(e).__name__, e)
+
+    def _get_subscription_vms(self, sub_index, sub):
+        """Get VMs from a single subscrption.
+
+        Yields:
+            tuple: A tuple which when unpacked forms valid arguments for
+                :meth:`_get_vm_instance_views`.
+
+        """
+        try:
+            tenant = self._tenant
+            creds = self._credentials
+            sub_id = sub.get('subscription_id')
+
+            compute_client = ComputeManagementClient(creds, sub_id)
+            vm_list = compute_client.virtual_machines.list_all()
+
+            for vm_index, vm in enumerate(vm_list):
+                vm = vm.as_dict()
+
+                _log.info('Found VM #%d: %s; %s',
+                          vm_index, vm.get('name'),
+                          util.outline_az_sub(sub_index, sub, tenant))
+
+                # Each VM is a unit of work.
+                yield (vm_index, vm, sub_index, sub)
+
+                # Break after pulling data for self._max_recs number
+                # of VMs for a subscriber. Note that if
+                # self._max_recs is 0 or less, then the following
+                # condition never evaluates to True.
+                if vm_index + 1 == self._max_recs:
+                    _log.info('Stopping vm_instance_view fetch due '
+                              'to _max_recs: %d; %s', self._max_recs,
+                              util.outline_az_sub(sub_index, sub, tenant))
+                    break
+        except Exception as e:
+            _log.error('Failed to fetch VMs; %s; error: %s: %s',
+                       util.outline_az_sub(sub_index, sub, tenant),
+                       type(e).__name__, e)
+
+    def _get_vm_instance_views(self, vm_index, vm, sub_index, sub):
+        """Get virtual machine records with instance view details.
+
+        Arguments:
+            vm_index (int): Virtual machine index (for logging only).
+            vm (dict): Raw virtual machine record.
+            sub_index (int): Subscription index (for logging only).
+            sub (Subscription): Azure subscription object.
+
+        Yields:
+            dict: An Azure virtual machine record with instance view details.
+
+        """
+        vm_name = vm.get('name')
+        _log.info('Working on VM #%d: %s; %s', vm_index, vm_name,
+                  util.outline_az_sub(sub_index, sub, self._tenant))
+        try:
+            creds = self._credentials
+            sub_id = sub.get('subscription_id')
+            compute_client = ComputeManagementClient(creds, sub_id)
+            vm_id = vm.get('id')
+            rg_name = tools.parse_resource_id(vm_id)['resource_group']
+            vm_iv = compute_client.virtual_machines.instance_view(rg_name,
+                                                                  vm_name)
+            vm_iv = vm_iv.as_dict()
+            yield _process_vm_instance_view(vm_index, vm, vm_iv,
+                                            sub_index, sub, self._tenant)
+        except Exception as e:
+            _log.error('Failed to fetch vm_instance_view for VM #%d: '
+                       '%s; %s; error: %s: %s', vm_index, vm_name,
+                       util.outline_az_sub(sub_index, sub, self._tenant),
+                       type(e).__name__, e)
 
     def done(self):
-        """Perform clean up tasks.
-
-        Currently, this method does nothing because there are no clean
-        up tasks associated with the :class:`AzVM` plugin. This
-        may change in future.
-        """
+        """Log a message that this plugin is done."""
+        _log.info('Done; tenant: %s; processes: %s; threads: %s',
+                  self._tenant, self._processes, self._threads)
 
 
-def _get_record(compute_client, subscription_id, max_recs):
-    """Get virtual machine records with instance view details.
-
-    Arguments:
-        compute_client (ComputeManagementClient): Compute management client.
-        subscription_id (str): Subscription ID.
-        max_recs (int): Maximum number of records to fetch.
-
-    Yields:
-        dict: An Azure virtual machine record with instance view details.
-
-    """
-    try:
-        virtual_machines_iter = compute_client.virtual_machines.list_all()
-
-        for vm_index, vm in enumerate(virtual_machines_iter):
-            rg_name = tools.parse_resource_id(vm.id)['resource_group']
-            vm_iv = compute_client.virtual_machines.instance_view(rg_name,
-                                                                  vm.name)
-            yield from _process_vm_instance_view(vm, vm_iv,
-                                                 vm_index, subscription_id)
-
-            # Break after pulling data for self._max_recs number of
-            # VMs for a subscriber. Note that if self._max_recs is 0 or
-            # less, then the following condition never evaluates to True.
-            if vm_index + 1 == max_recs:
-                _log.info('Ending records fetch for subscription due '
-                          'to _max_recs: %d; subscription_id: %s; ',
-                          max_recs, subscription_id)
-                break
-    except CloudError as e:
-        _log.error('Failed to fetch details for vm_instance_view; '
-                   'subscription_id: %s; error: %s: %s',
-                   subscription_id, type(e).__name__, e)
-
-
-def _process_vm_instance_view(vm, vm_iv, vm_index, subscription_id):
+def _process_vm_instance_view(vm_index, vm, vm_iv,
+                              sub_index, sub, tenant):
     """Process virtual machine record and yeild them.
 
     Arguments:
-        vm (VirtualMachine): Virtual Machine Descriptor
-        vm_iv (VirtualMachineInstanceView): Virtual Machine Instance view
-        subscription_id (str): Subscription ID.
+        vm_index (int): Virtual machine index (for logging only).
+        vm (dict): Raw virtual machine record.
+        vm_iv (dict): Raw virtual machine instance view record.
+        sub_index (int): Subscription index (for logging only).
+        sub (Subscription): Azure subscription object.
+        tenant (str): Azure tenant ID.
 
     Yields:
         dict: An Azure record of type ``vm_instance_view``.
 
     """
-    raw_record = vm.as_dict()
-    raw_record['instance_view'] = vm_iv.as_dict()
+    vm['instance_view'] = vm_iv
     record = {
-        'raw': raw_record,
+        'raw': vm,
         'ext': {
             'cloud_type': 'azure',
             'record_type': 'vm_instance_view',
-            'subscription_id': subscription_id,
+            'subscription_id': sub.get('subscription_id'),
+            'subscription_name': sub.get('display_name'),
+            'subscription_state': sub.get('state'),
         },
         'com': {
             'cloud_type': 'azure',
             'record_type': 'compute',
-            'reference': raw_record.get('id')
+            'reference': vm.get('id')
         }
     }
     record['ext'] = util.merge_dicts(
@@ -153,27 +218,28 @@ def _process_vm_instance_view(vm, vm_iv, vm_index, subscription_id):
         _get_normalized_vm_statuses(vm_iv),
         _get_normalized_vm_disk_encryption_status(vm, vm_iv)
         )
-    _log.info('Found vm_instance_view #%d; subscription_id: %s; name: %s',
-              vm_index, subscription_id, record['raw'].get('name'))
-    yield record
+    _log.info('Found vm_instance_view #%d: %s; %s',
+              vm_index, vm.get('name'),
+              util.outline_az_sub(sub_index, sub, tenant))
+    return record
 
 
 def _get_normalized_vm_statuses(vm_iv):
     """Iterate over a list of virtual machine statuses and normalize them.
 
     Arguments:
-        vm_iv (VirtualMachineInstanceView): Virtual Machine Instance View
+        vm_iv (dict): Raw virtual machine instance view record.
 
     Returns:
         dict: Normalized virtual machine statuses
 
     """
     normalized_statuses = {}
-    for s in vm_iv.statuses:
-        if s.code.startswith('PowerState/'):
-            code_elements = s.code.split('/', 1)
-            normalized_statuses['power_state'] = \
-                code_elements[1].lower()
+    for s in vm_iv.get('statuses', []):
+        code = s.get('code', '')
+        if code.startswith('PowerState/'):
+            code_elements = code.split('/', 1)
+            normalized_statuses['power_state'] = code_elements[1].lower()
     return normalized_statuses
 
 
@@ -181,27 +247,29 @@ def _get_normalized_vm_disk_encryption_status(vm, vm_iv):
     """Iterate over a list of virtual machine disks normalize them.
 
     Arguments:
-        vm (VirtualMachine): Virtual Machine
-        vm_iv (VirtualMachineInstanceView): Virtual Machine Instance View
+        vm (dict): Raw virtual machine record.
+        vm_iv (dict): Raw virtual machine instance view record.
 
     Returns:
         dict: Normalized virtual machine disk encryption statuses
 
     """
-    os_disk_name = vm.storage_profile.os_disk.name
+    os_disk_name = vm.get('storage_profile', {}).get('os_disk', {}).get('name')
     disk_enc_statuses = {}
-    for disk in vm_iv.disks:
-        if disk.name == os_disk_name:
-            if disk.encryption_settings is None:
+    for disk in vm_iv.get('disks', []):
+        disk_name = disk.get('name')
+        disk_encryption_settings = disk.get('encryption_settings')
+        if disk_name == os_disk_name:
+            if disk_encryption_settings is None:
                 disk_enc_statuses['os_disk_encrypted'] = False
             else:
                 disk_enc_statuses['os_disk_encrypted'] = \
-                    disk.encryption_settings[0].enabled
+                    disk_encryption_settings[0].get('enabled')
         else:
             if disk_enc_statuses.get('all_data_disks_encrypted', True):
-                if disk.encryption_settings is None:
+                if disk_encryption_settings is None:
                     disk_enc_statuses['all_data_disks_encrypted'] = False
                 else:
                     disk_enc_statuses['all_data_disks_encrypted'] = \
-                        disk.encryption_settings[0].enabled
+                        disk_encryption_settings[0].get('enabled')
     return disk_enc_statuses

--- a/cloudmarker/ioworkers.py
+++ b/cloudmarker/ioworkers.py
@@ -1,0 +1,139 @@
+"""Concurrent input/output workers implementation.
+
+This module offers a :func:`run` function to run a specified function in
+a large number of threads. Unlike the standard library :mod:`threading`
+module of Python, this module lets us run threads on multiple CPUs at
+the same time. This is achieved by first creating multiple processes
+using the standard library :mod:`multiprocessing` package. These
+processes can utilize multiple CPUs. The threads are then launched under
+these multiple processes.
+"""
+
+
+import logging
+import multiprocessing
+import os
+import threading
+
+_log = logging.getLogger(__name__)
+
+
+def run(input_func, output_func, processes=0, threads=0, log_tag=''):
+    """Run concurrent input/output workers with specified functions.
+
+    A two-level hierarchy of workers are created using both
+    multiprocessing as well as multithreading. At first, ``processes``
+    number of worker processes are created. Then within each process
+    worker, ``threads`` number of worker threads are created. Thus, in
+    total, ``processes * threads`` number of worker threads are created.
+
+    Arguments:
+        input_func (callable): A callable which when called yields
+            tuples. Each tuple must represent arguments to be passed to
+            ``output_func``.
+        output_func (callable): A callable that can accept as arguments
+            an unpacked tuple yielded by ``input_func``. When called,
+            this callable must work on the arguments and return an
+            output value. This callable must not return ``None`` for any
+            input.
+        processes (int): Number of worker processes to run. If
+            unspecified or ``0`` or negative integer is specified, then
+            the number returned by :func:`os.cpu_count` is used.
+        threads (int): Number of worker threads to run in each process.
+            If unspecified or ``0`` or negative integer is specified,
+            then `5` multiplied by the number returned by
+            :func:`os.cpu_count` is used.
+        log_tag (str): String to include in every log message. This
+            helps in differentiating between different workers invoked
+            by different callers.
+
+    Yields:
+        Each output value returned by ``output_func``.
+
+    """
+    if processes <= 0:
+        processes = os.cpu_count()
+
+    if threads <= 0:
+        threads = os.cpu_count() * 5
+
+    if log_tag != '':
+        log_tag += ': '
+
+    in_q = multiprocessing.Queue()
+    out_q = multiprocessing.Queue()
+
+    # Create process workers.
+    process_workers = []
+    for _ in range(processes):
+        w = multiprocessing.Process(target=_process_worker,
+                                    args=(in_q, out_q, threads,
+                                          output_func, log_tag))
+        w.start()
+        process_workers.append(w)
+
+    # Get input data for thread workers to work on.
+    for args in input_func():
+        in_q.put(args)
+
+    # Tell each thread worker that there is no more input to work on.
+    for _ in range(processes * threads):
+        in_q.put(None)
+
+    # Consume output objects from thread workers and yield them.
+    yield from _get_output(out_q, processes, threads, log_tag)
+
+    # Wait for process workers to terminate.
+    for w in process_workers:
+        w.join()
+
+    _log.info('%sDone', log_tag)
+
+
+def _process_worker(in_q, out_q, threads, output_func, log_tag):
+    """Process worker."""
+    _log.info('process_worker: %sStarted', log_tag)
+    thread_workers = []
+    for _ in range(threads):
+        w = threading.Thread(target=_thread_worker,
+                             args=(in_q, out_q, output_func, log_tag))
+        w.start()
+        thread_workers.append(w)
+    for w in thread_workers:
+        w.join()
+    _log.info('process_worker: %sStopped', log_tag)
+
+
+def _thread_worker(in_q, out_q, output_func, log_tag):
+    """Thread worker."""
+    _log.info('thread_worker: %sStarted', log_tag)
+    while True:
+        try:
+            work = in_q.get()
+            if work is None:
+                _log.info('thread_worker: %sStopping', log_tag)
+                out_q.put(None)
+                break
+            for record in output_func(*work):
+                out_q.put(record)
+        except Exception as e:
+            _log.exception('thread_worker: %sFailed; error: %s: %s',
+                           log_tag, type(e).__name__, e)
+    _log.info('thread_worker: %sStopped', log_tag)
+
+
+def _get_output(out_q, processes, threads, log_tag):
+    """Get output from output queue and yield them."""
+    stopped_threads = 0
+    while True:
+        try:
+            record = out_q.get()
+            if record is None:
+                stopped_threads += 1
+                if stopped_threads == processes * threads:
+                    break
+                continue
+            yield record
+        except Exception as e:
+            _log.exception('%sFailed to get output; error: %s: %s',
+                           log_tag, type(e).__name__, e)

--- a/cloudmarker/test/test_ioworkers.py
+++ b/cloudmarker/test/test_ioworkers.py
@@ -1,0 +1,19 @@
+"""Tests for ioworkers module."""
+
+import unittest
+
+from cloudmarker import ioworkers
+
+
+class UtilTest(unittest.TestCase):
+    """Tests for util module."""
+
+    def test_run_default_workers(self):
+        out = ioworkers.run(lambda: ((i,) for i in range(5)),
+                            lambda x: [x**2])
+        self.assertEqual(set(out), {0, 1, 4, 9, 16})
+
+    def test_run_worker_counts(self):
+        out = ioworkers.run(lambda: ((i,) for i in range(5)),
+                            lambda x: [x**2], 1, 1)
+        self.assertEqual(list(out), [0, 1, 4, 9, 16])

--- a/cloudmarker/test/test_util.py
+++ b/cloudmarker/test/test_util.py
@@ -265,3 +265,13 @@ class UtilTest(unittest.TestCase):
     def test_pluralize_two_surplus_suffix(self):
         with self.assertRaises(util.PluralizeError):
             util.pluralize(2, 'sky', 'y', 'ies', 'foo')
+
+    def test_outline_az_sub(self):
+        sub = {
+            'subscription_id': 'foo_id',
+            'display_name': 'foo_name',
+            'state': 'foo_state',
+        }
+        self.assertEqual(util.outline_az_sub(1, sub, 'foo_tenant'),
+                         'subscription #1: foo_id (foo_name) '
+                         '(foo_state); tenant: foo_tenant')

--- a/cloudmarker/util.py
+++ b/cloudmarker/util.py
@@ -581,6 +581,23 @@ def send_email(from_addr, to_addrs, subject, content,
                    type(e).__name__, e)
 
 
+def outline_az_sub(sub_index, sub, tenant):
+    """Return a summary of an Azure subscription for logging purpose.
+
+    Arguments:
+        sub_index (int): Subscription index.
+        sub (Subscription): Azure subscription model object.
+        tenant (str): Azure Tenant ID.
+
+    Returns:
+        str: Return a string that can be used in log messages.
+
+    """
+    return ('subscription #{}: {} ({}) ({}); tenant: {}'
+            .format(sub_index, sub.get('subscription_id'),
+                    sub.get('display_name'), sub.get('state'), tenant))
+
+
 class PluginError(Exception):
     """Represents an error while loading a plugin."""
 

--- a/docs/api/cloudmarker.rst
+++ b/docs/api/cloudmarker.rst
@@ -27,6 +27,14 @@ cloudmarker.baseconfig module
     :undoc-members:
     :show-inheritance:
 
+cloudmarker.ioworkers module
+----------------------------
+
+.. automodule:: cloudmarker.ioworkers
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 cloudmarker.manager module
 --------------------------
 

--- a/pylama.ini
+++ b/pylama.ini
@@ -23,6 +23,19 @@ ignore = R0913,W0703
 # R0913 Too many arguments (6/5) [pylint]
 # W0703 Catching too general exception Exception [pylint]
 
+[pylama:cloudmarker/clouds/azcloud.py]
+ignore = R0911,R0913,W0703
+
+# R0911 Too many return statements (9/6) [pylint]
+# R0913 Too many arguments (6/5) [pylint]
+# W0703 Catching too general exception Exception [pylint]
+
+[pylama:cloudmarker/clouds/azvm.py]
+ignore = R0913,W0703
+
+# R0913 Too many arguments (6/5) [pylint]
+# W0703 Catching too general exception Exception [pylint]
+
 [pylama:cloudmarker/clouds/gcpcloud.py]
 ignore = E1101
 
@@ -53,15 +66,21 @@ ignore = R0913,W0703
 # R0913 Too many arguments (10/5) [pylint]
 # W0703 Catching too general exception Exception
 
+[pylama:cloudmarker/ioworkers.py]
+ignore = W0703
+
+# W0703 Catching too general exception Exception
+
 [pylama:cloudmarker/baseconfig.py]
 ignore = E501
 
 # E501 line too long (82 > 79 characters) [pycodestyle]
 
 [pylama:cloudmarker/test/test_*.py]
-ignore = D102,C0111,R0903,R0904,R0201,W0613
+ignore = D102,D107,C0111,R0903,R0904,R0201,W0613
 
 # D102 Missing docstring in public method [pydocstyle]
+# D107 Missing docstring in __init__ [pydocstyle]
 # C0111 Missing method docstring [pylint]
 # R0903 Too few public methods (0/2) [pylint]
 # R0904 Too many public methods (23/20) [pylint]


### PR DESCRIPTION
Both `AzCloud` and `AzVM` now rely on multiprocessing and multithreading
to pull resources concurrently from Azure cloud in order to complete its
scan faster.

All of the multiprocessing and multithreading code involved is put in a
new `ioworkers` module. `AzCloud` and `AzVM` invoke `ioworkers.run()` to
launch multiple worker processes each of which launch multiple worker
threads. The callers, i.e., `AzCloud` and `AzVM`, need to provide this
`ioworkers.run()` function two callback functions:

  - An input function which when invoked yields tuples where each tuple
    defines a unit of work.
  - An output function which works on each tuple yielded by the input
    function, does something with it, and then yields outputs.

The output functions are run concurrently by `ioworkers` in multiple
worker threads within multiple worker processes. This two-level
approach, i.e., worker threads within worker processes, has been chosen
to maximize utilization of CPUs. This approaches provides a good balance
between the following two extremes:

  - Using a large number of processes only would consume too many IPC
    resources and increase the overhead of context switching for
    processes.
  - Using a large number of threads only does not scale well in Python
    due to global interpreter lock (GIL) which allows only one thread to
    execute at a time.

Lauching multiple workers sidesteps GIL and lets us utilize multiple
CPUs. Launching multiple threads within each process lets us scale even
further without incurring the overhead of more processes.