### PR TITLE
Set project version to dev version

### DIFF
--- a/cloudmarker/__init__.py
+++ b/cloudmarker/__init__.py
@@ -1,5 +1,5 @@
 """Cloudmarker - Cloud security monitoring framework."""
 
 
-__version__ = '0.1.0'
+__version__ = '0.2.0.dev1'
 __author__ = 'Cloudmarker Authors and Contributors'


### PR DESCRIPTION
The project should have a dev version most of the time, so that someone
cloning this project knows that the checked out code is development
code. One can then checkout a stable version using tags. Only prior to a
release, we will be changing the project version to a stable version.

We are using `A.B.C.devN` notation for dev versions and `A.B.C` notation
for stable versions.