### PR TITLE
Add PostgresSQL to resources evaluated by AzCloud

### DIFF
--- a/cloudmarker/clouds/azcloud.py
+++ b/cloudmarker/clouds/azcloud.py
@@ -11,6 +11,7 @@ from azure.common.credentials import ServicePrincipalCredentials
 from azure.mgmt.compute import ComputeManagementClient
 from azure.mgmt.network import NetworkManagementClient
 from azure.mgmt.rdbms.mysql import MySQLManagementClient
+from azure.mgmt.rdbms.postgresql import PostgreSQLManagementClient
 from azure.mgmt.resource import ResourceManagementClient, SubscriptionClient
 from azure.mgmt.storage import StorageManagementClient
 
@@ -86,7 +87,8 @@ class AzCloud:
 
             record_types = ('virtual_machine', 'app_gateway', 'lb', 'nic',
                             'nsg', 'public_ip', 'storage_account',
-                            'resource_group', 'mysql_server')
+                            'resource_group', 'mysql_server',
+                            'postgresql_server')
 
             tenant = self._tenant
             for sub_index, sub in enumerate(sub_list):
@@ -201,6 +203,10 @@ def _get_resource_iterator(record_type, credentials,
         client = MySQLManagementClient(credentials, sub_id)
         return client.servers.list()
 
+    if record_type == 'postgresql_server':
+        client = PostgreSQLManagementClient(credentials, sub_id)
+        return client.servers.list()
+
     # If control reaches here, there is a bug in this plugin. It means
     # there is a value in record_types variable in _get_subscriptions
     # that is not handled in the above if-statements.
@@ -230,6 +236,7 @@ def _get_record(iterator, azure_record_type, max_recs,
     record_type_map = {
         'virtual_machine': 'compute',
         'mysql_server': 'rdbms',
+        'postgresql_server': 'rdbms',
     }
 
     for i, v in enumerate(iterator):
@@ -261,7 +268,7 @@ def _get_record(iterator, azure_record_type, max_recs,
             yield from _get_normalized_firewall_rules(
                 record, sub_index, sub, tenant)
 
-        if azure_record_type == 'mysql_server':
+        if azure_record_type in ['mysql_server', 'postgresql_server']:
             yield from _get_normalized_rdbms_record(record)
             return
 

--- a/cloudmarker/test/test_azcloud.py
+++ b/cloudmarker/test/test_azcloud.py
@@ -72,6 +72,10 @@ class AzCloudTest(unittest.TestCase):
         self._MockMySQLManagementClient = m
         m().servers.list.return_value = [mock_record]
 
+        m = self._patch('PostgreSQLManagementClient')
+        self._MockPostgreSQLManagementClient = m
+        m().servers.list.return_value = [mock_record]
+
     def test_nsg_single_security_rule(self):
         mock_nsg_dict = {'security_rules': [{}]}
         mock_nsg = SimpleMock(mock_nsg_dict)
@@ -578,5 +582,29 @@ class AzCloudTest(unittest.TestCase):
                          'azure_mysql_server_id')
         self.assertEqual(records[0]['com']['reference'],
                          'azure_mysql_server_id')
+        self.assertEqual(records[0]['com']['record_type'],
+                         'rdbms')
+
+    def test_postgresql_server_record(self):
+        mock_postgresql_server_dict = {
+            'id': 'azure_postgresql_server_id',
+            'ssl_enforcement': 'Enabled',
+        }
+        mock_postgresql_server = SimpleMock(mock_postgresql_server_dict)
+
+        m = self._MockPostgreSQLManagementClient
+        m().servers.list.return_value = [mock_postgresql_server]
+
+        records = list(azcloud.AzCloud('', '', '').read())
+        records = [
+            r for r in records
+            if r['ext']['record_type'] == 'postgresql_server'
+        ]
+        self.assertEqual(records[0]['com']['tls_enforced'],
+                         True)
+        self.assertEqual(records[0]['ext']['reference'],
+                         'azure_postgresql_server_id')
+        self.assertEqual(records[0]['com']['reference'],
+                         'azure_postgresql_server_id')
         self.assertEqual(records[0]['com']['record_type'],
                          'rdbms')

--- a/pylama.ini
+++ b/pylama.ini
@@ -24,11 +24,12 @@ ignore = R0913,W0703
 # W0703 Catching too general exception Exception [pylint]
 
 [pylama:cloudmarker/clouds/azcloud.py]
-ignore = R0911,R0913,W0703
+ignore = R0911,R0913,W0703,C901
 
 # R0911 Too many return statements (9/6) [pylint]
 # R0913 Too many arguments (6/5) [pylint]
 # W0703 Catching too general exception Exception [pylint]
+# C901 Function is too complex [mccabe]
 
 [pylama:cloudmarker/clouds/azvm.py]
 ignore = R0913,W0703


### PR DESCRIPTION
The PostgreSQL servers associated with a subscription are evaluated
and processed. A record is generated, with the value of `record_type`
set to `postgresql_server` in the `ext` bucket and `record_type`
set to `rdbms` set in the `com` bucket of the record.