### PR TITLE
Add RDBMSEnforceTLSEvent plugin

### DIFF
--- a/cloudmarker/clouds/azcloud.py
+++ b/cloudmarker/clouds/azcloud.py
@@ -472,10 +472,10 @@ def _get_normalized_rdbms_record(rdbms_record):
         'raw': rdbms_record.get('raw', {}),
         'ext': util.merge_dicts(rdbms_record.get('ext'), {
             'reference': rdbms_record.get('raw', {}).get('id'),
-            'ssl_connection_enabled': ssl_connection_enabled,
         }),
         'com': util.merge_dicts(rdbms_record.get('com'), {
             'reference': rdbms_record.get('raw', {}).get('id'),
+            'tls_enforced': ssl_connection_enabled,
         }),
 
     }

--- a/cloudmarker/events/rdbmsenforcetlsevent.py
+++ b/cloudmarker/events/rdbmsenforcetlsevent.py
@@ -1,0 +1,100 @@
+"""RDBMS Enforce TLS/SSL Event.
+
+This module defines the :class:`RDBMSEnforceTLSEvent` class that
+identifies RDBMS servers which have TLS/SSL connection enforcement
+disabled. This plugin works on the  properties found in the ``com``
+bucket of ``rdbms`` records.
+"""
+
+
+import logging
+
+from cloudmarker import util
+
+_log = logging.getLogger(__name__)
+
+
+class RDBMSEnforceTLSEvent:
+    """Az RDBMS TLS/SSL enforcement event plugin."""
+
+    def __init__(self):
+        """Create an instance of :class:`RDBMSEnforceTLSEvent`."""
+
+    def eval(self, record):
+        """Evaluate RDBMS servers for TLS connection enforcement.
+
+        Arguments:
+            record (dict): An RDBMS record.
+
+        Yields:
+            dict: An event record representing an RDBMS where TLS
+            connection enforcement is disabled
+
+        """
+        com = record.get('com', {})
+        if com is None:
+            return
+
+        if com.get('record_type') != 'rdbms':
+            return
+
+        ext = record.get('ext', {})
+        if ext is None:
+            return
+
+        # True, None, missing key or any other value will not
+        # genarated an event. An event will be generated only if
+        # the value of `tls_enforced` is False.
+        if com.get('tls_enforced') is False:
+            yield from _get_rdbms_tls_enforcement_event(
+                com, ext)
+
+    def done(self):
+        """Perform cleanup work.
+
+        Currently, this method does nothing. This may change in future.
+        """
+
+
+def _get_rdbms_tls_enforcement_event(com, ext):
+    """Generate event for TLS enforcement disabled.
+
+    Arguments:
+        com (dict): RDBMS record `com` bucket
+        ext (dict): RDBMS record `ext` bucket
+    Returns:
+        dict: An event record representing RDBMS with SSL
+        connection enforcement disabled
+
+    """
+    friendly_cloud_type = util.friendly_string(com.get('cloud_type'))
+    friendly_rdbms_type = util.friendly_string(ext.get('record_type'))
+
+    reference = com.get('reference')
+    description = (
+        '{} {} {} has TLS/SSL enforcement disabled.'
+        .format(friendly_cloud_type, friendly_rdbms_type, reference)
+    )
+    recommendation = (
+        'Check {} {} {} and enable TLS/SSL enforcement.'
+        .format(friendly_cloud_type, friendly_rdbms_type, reference)
+    )
+
+    event_record = {
+        # Preserve the extended properties from the RDBMS
+        # record because they provide useful context to
+        # locate the RDBMS that led to the event.
+        'ext': util.merge_dicts(ext, {
+            'record_type': 'rdbms_enforce_tls_event'
+        }),
+        'com': {
+            'cloud_type': com.get('cloud_type'),
+            'record_type': 'rdbms_enforce_tls_event',
+            'reference': reference,
+            'description': description,
+            'recommendation': recommendation,
+        }
+    }
+
+    _log.info('Generating rdbms_enforce_tls_event; %r', event_record)
+    yield event_record

--- a/cloudmarker/test/test_azcloud.py
+++ b/cloudmarker/test/test_azcloud.py
@@ -572,7 +572,7 @@ class AzCloudTest(unittest.TestCase):
             r for r in records
             if r['ext']['record_type'] == 'mysql_server'
         ]
-        self.assertEqual(records[0]['ext']['ssl_connection_enabled'],
+        self.assertEqual(records[0]['com']['tls_enforced'],
                          True)
         self.assertEqual(records[0]['ext']['reference'],
                          'azure_mysql_server_id')

--- a/cloudmarker/test/test_rdbmsenforcetlsevent.py
+++ b/cloudmarker/test/test_rdbmsenforcetlsevent.py
@@ -1,0 +1,63 @@
+"""Tests for RDBMSEnforceTLSEvent plugin."""
+
+
+import copy
+import unittest
+
+from cloudmarker.events import rdbmsenforcetlsevent
+
+base_record = {
+    'com':  {
+        'tls_enforced':  True,
+        'record_type': 'rdbms',
+    }
+}
+
+
+class RDBMSEnforceTLSEventTest(unittest.TestCase):
+    """Tests for RDBMSEnforceTLSEvent plugin."""
+
+    def test_com_bucket_missing(self):
+        record = copy.deepcopy(base_record)
+        record['com'] = None
+        plugin = rdbmsenforcetlsevent.RDBMSEnforceTLSEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_com_bucket_record_type_non_rdbms(self):
+        record = copy.deepcopy(base_record)
+        record['com']['record_type'] = 'non_rdbms'
+        plugin = rdbmsenforcetlsevent.RDBMSEnforceTLSEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_tls_enforcement_enabled(self):
+        record = copy.deepcopy(base_record)
+        plugin = rdbmsenforcetlsevent.RDBMSEnforceTLSEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_tls_enforcement_missing(self):
+        record = copy.deepcopy(base_record)
+        del record['com']['tls_enforced']
+        plugin = rdbmsenforcetlsevent.RDBMSEnforceTLSEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_tls_enforcement_none(self):
+        record = copy.deepcopy(base_record)
+        record['com']['tls_enforced'] = None
+        plugin = rdbmsenforcetlsevent.RDBMSEnforceTLSEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_tls_enforcement_disbled(self):
+        record = copy.deepcopy(base_record)
+        record['com']['tls_enforced'] = False
+        plugin = rdbmsenforcetlsevent.RDBMSEnforceTLSEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0]['ext']['record_type'],
+                         'rdbms_enforce_tls_event')
+        self.assertEqual(events[0]['com']['record_type'],
+                         'rdbms_enforce_tls_event')

--- a/cloudmarker/util.py
+++ b/cloudmarker/util.py
@@ -359,7 +359,9 @@ def friendly_string(technical_string):
     """
     phrase_map = {
         'azure': 'Azure',
-        'gcp': 'Google Cloud Platform (GCP)'
+        'gcp': 'Google Cloud Platform (GCP)',
+        'mysql_server': 'MySQL Server',
+        'postgresql_server': 'PostgreSQL Server'
     }
     return phrase_map.get(technical_string, technical_string)
 

--- a/pylama.ini
+++ b/pylama.ini
@@ -101,3 +101,8 @@ ignore = R0201
 ignore = R0201
 
 # R0201 Method could be a function [pylint]
+
+[pylama:cloudmarker/events/rdbmsenforcetlsevent.py]
+ignore = R0201
+
+# R0201 Method could be a function [pylint]


### PR DESCRIPTION
The `RDBMSEnforceTLSEvent` plugin evaluates the records of type
'rdbms' and generates events of type `rdbms_enforce_tls_event` if
TLS/SSL enforcement is disabled on the server.

Enforcing TLS/SSL connection between the server and the client applications
help prevent `Man In The Middle ` attack by encrypting data stream
between the server and the client application.