### PR TITLE
Replace os.rename() with os.replace() in FileStore

### DIFF
--- a/cloudmarker/stores/filestore.py
+++ b/cloudmarker/stores/filestore.py
@@ -86,4 +86,4 @@ class FileStore:
 
             # Rename the temporary file to a JSON file.
             json_file_path = os.path.join(self._path, worker_name) + '.json'
-            os.rename(tmp_file_path, json_file_path)
+            os.replace(tmp_file_path, json_file_path)


### PR DESCRIPTION
The cross-platform behavior of `os.rename()` is inconsistent.
While trying to setup a development environment on Windows,
`os.rename()` caused errors to be thrown as seen below.

    File "c:\users\...", line 89, in done
        os.rename(tmp_file_path, json_file_path)
    FileExistsError: [WinError 183] Cannot create a file when that file
    already exists: '/tmp/cloudmarker\\mymockaudit_mymockcloud.tmp' ->
    '/tmp/cloudmarker\\mymockaudit_mymockcloud.json'
    mymockaudit_filestore: Failed; done() error: FileExistsError:
    [WinError 183] Cannot create a file when that file already exists:
    '/tmp/cloudmarker\\no_worker.tmp' ->
    '/tmp/cloudmarker\\no_worker.json'

Changing `os.rename()` to `os.replace()` has fixed the issue, as
`os.replace()` always guarantees to replace the file regardless
of the platform.