### PR TITLE
Fix UserWarning in MongoDBStore

### DIFF
--- a/cloudmarker/stores/mongodbstore.py
+++ b/cloudmarker/stores/mongodbstore.py
@@ -34,7 +34,8 @@ class MongoDBStore:
             host=host,
             port=port,
             username=username,
-            password=password
+            password=password,
+            connect=False
         )
 
         self._collection = self._client[db][collection]


### PR DESCRIPTION
Since Cloudmarker runs in multiprocess mode the
connect call in `cloudmarker/stores/mongodbstore.py`
MongoClient was throwing a `UserWarning: MongoClient
opened before fork. Create MongoClient only after
forking. See PyMongo's documentation for details:
http://api.mongodb.org/python/current/faq.html#is-pymongo-fork-safe
"MongoClient opened before fork. Create MongoClient
only "`.
In this commit the call to MongoDB via is
made lazy. The connection to the database is made on
the first operation.