### PR TITLE
Pull all projects for a keyfile in GCPCloud

### DIFF
--- a/pylama.ini
+++ b/pylama.ini
@@ -38,10 +38,11 @@ ignore = R0913,W0703
 # W0703 Catching too general exception Exception [pylint]
 
 [pylama:cloudmarker/clouds/gcpcloud.py]
-ignore = E1101
+ignore = E1101,W0703
 
 # E1101 Instance of 'Resource' has no 'firewalls' member [pylint]
 # E1101 Instance of 'Resource' has no 'instances' member [pylint]
+# W0703 Catching too general exception Exception [pylint]
 
 [pylama:cloudmarker/stores/mongodbstore.py]
 ignore = R0913


### PR DESCRIPTION
Using the `projects().list()` API provided by google-api-python-client
library, all available projects for a given keyfile can be obtained.
Successively, all projects are iterated through and the instance and
firewall data is recorded.