### PR TITLE
Add AzSQLDatabaseTDEEvent plugin

### DIFF
--- a/cloudmarker/baseconfig.py
+++ b/cloudmarker/baseconfig.py
@@ -41,6 +41,9 @@ plugins:
   rdbmsenforcetlsevent:
     plugin: cloudmarker.events.rdbmsenforcetlsevent.RDBMSEnforceTLSEvent
 
+  azsqldatabasetdeevent:
+    plugin: cloudmarker.events.azsqldatabasetdeevent.AzSQLDatabaseTDEEvent
+
   mockevent:
     plugin: cloudmarker.events.mockevent.MockEvent
 

--- a/cloudmarker/events/azsqldatabasetdeevent.py
+++ b/cloudmarker/events/azsqldatabasetdeevent.py
@@ -1,0 +1,95 @@
+"""Microsoft Azure SQL DB Transparent Data Encryption (TDE) event.
+
+This module defines the :class:`AzSQLDatabaseTDEEvent` class that
+identifies if a SQL database has TDE disabled . This plugin works on the
+SQL DB properties found in the ``ext`` bucket of ``sql_db`` records.
+"""
+
+
+import logging
+
+from cloudmarker import util
+
+_log = logging.getLogger(__name__)
+
+
+class AzSQLDatabaseTDEEvent:
+    """Azure SQL database TDE event plugin."""
+
+    def __init__(self):
+        """Create an instance of :class:`AzSQLDatabaseTDEEvent`."""
+
+    def eval(self, record):
+        """Evaluate Azure SQL DB for disabled TDE.
+
+        Arguments:
+            record (dict): A SQL DB record.
+
+        Yields:
+            dict: An event record representing an Azure SQL DB with
+            TDE disabled
+
+        """
+        com = record.get('com', {})
+        if com is None:
+            return
+
+        if com.get('cloud_type') != 'azure':
+            return
+
+        ext = record.get('ext', {})
+        if ext is None:
+            return
+
+        if ext.get('record_type') != 'sql_db':
+            return
+
+        if ext.get('tde_enabled'):
+            return
+        yield from _get_sql_db_tde_disabled_event(com, ext)
+
+    def done(self):
+        """Perform cleanup work.
+
+        Currently, this method does nothing. This may change in future.
+        """
+
+
+def _get_sql_db_tde_disabled_event(com, ext):
+    """Generate SQL DB disabled TDE event.
+
+    Arguments:
+        com (dict): SQL DB record `com` bucket
+        ext (dict): SQL DB record `ext` bucket
+    Returns:
+        dict: An event record representing SQL DB with disabled TDE
+
+    """
+    friendly_cloud_type = util.friendly_string(com.get('cloud_type'))
+    reference = com.get('reference')
+    description = (
+        '{} SQL DB {} has TDE disabled.'
+        .format(friendly_cloud_type, reference)
+    )
+    recommendation = (
+        'Check {} SQL DB {} and enable TDE.'
+        .format(friendly_cloud_type, reference)
+    )
+    event_record = {
+        # Preserve the extended properties from the virtual
+        # machine record because they provide useful context to
+        # locate the virtual machine that led to the event.
+        'ext': util.merge_dicts(ext, {
+            'record_type': 'sql_db_tde_event'
+        }),
+        'com': {
+            'cloud_type': com.get('cloud_type'),
+            'record_type': 'sql_db_tde_event',
+            'reference': reference,
+            'description': description,
+            'recommendation': recommendation,
+        }
+    }
+
+    _log.info('Generating sql_db_tde_event; %r', event_record)
+    yield event_record

--- a/cloudmarker/test/test_azsqldatabasetdeevent.py
+++ b/cloudmarker/test/test_azsqldatabasetdeevent.py
@@ -1,0 +1,71 @@
+"""Tests for AzSQLDatabaseTDEEvent plugin."""
+
+
+import copy
+import unittest
+
+from cloudmarker.events import azsqldatabasetdeevent
+
+base_record = {
+    'com':  {
+        'cloud_type': 'azure'
+    },
+    'ext': {
+        'record_type': 'sql_db',
+        'tde_enabled': True
+    }
+}
+
+
+class AzSQLDatabaseDisabledTDEEventTest(unittest.TestCase):
+    """Tests for AzSQLDatabaseTDEEvent plugin."""
+
+    def test_com_bucket_missing(self):
+        record = copy.deepcopy(base_record)
+        record['com'] = None
+        plugin = azsqldatabasetdeevent.AzSQLDatabaseTDEEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_cloud_non_azure(self):
+        record = copy.deepcopy(base_record)
+        record['com']['cloud_type'] = 'non_azure'
+        plugin = azsqldatabasetdeevent.AzSQLDatabaseTDEEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_ext_bucket_missing(self):
+        record = copy.deepcopy(base_record)
+        record['ext'] = None
+        plugin = azsqldatabasetdeevent.AzSQLDatabaseTDEEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_record_type_non_sql_db(self):
+        record = copy.deepcopy(base_record)
+        record['ext']['record_type'] = 'non_sql_db'
+        plugin = azsqldatabasetdeevent.AzSQLDatabaseTDEEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_tde_enabled(self):
+        record = copy.deepcopy(base_record)
+        plugin = azsqldatabasetdeevent.AzSQLDatabaseTDEEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_tde_disabled(self):
+        record = copy.deepcopy(base_record)
+        record['ext']['tde_enabled'] = False
+        plugin = azsqldatabasetdeevent.AzSQLDatabaseTDEEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0]['ext']['record_type'],
+                         'sql_db_tde_event')
+        self.assertEqual(events[0]['com']['cloud_type'],
+                         'azure')
+        self.assertEqual(events[0]['com']['record_type'],
+                         'sql_db_tde_event')
+        self.assertTrue('reference' in events[0]['com'])
+        self.assertIsNotNone(events[0]['com']['description'])
+        self.assertIsNotNone(events[0]['com']['recommendation'])

--- a/pylama.ini
+++ b/pylama.ini
@@ -116,4 +116,7 @@ ignore = R0913,W0703,R0201
 # W0703 Catching too general exception Exception [pylint]
 # R0201 Method could be a function [pylint]
 
+[pylama:cloudmarker/events/azsqldatabasetdeevent.py]
+ignore = R0201
 
+# R0201 Method could be a function [pylint]


### PR DESCRIPTION
The `AzSQLDatabaseTDEEvent` evaluates records of type 'sql_db'
for Azure cloud and generates event of type `sql_db_tde_event`
if Transparent Data Encryption (TDE) is disabled on the SQL database
being evaluated.

TDE protects data `at-rest` by encrypting data and logs using AES and
3DES encryption algorithms without changing existing applications.