### PR TITLE
Fix errors reported by pydocstyle 4.0.0

### DIFF
--- a/cloudmarker/alerts/emailalert.py
+++ b/cloudmarker/alerts/emailalert.py
@@ -22,6 +22,7 @@ class EmailAlert:
         argument is provided, it is ignored by this class because this
         class defines its own content from the event records it receives
         in its :meth:`write` method.
+
         """
         self._kwargs = kwargs
         self._buffer = []
@@ -31,6 +32,7 @@ class EmailAlert:
 
         Arguments:
             record (dict): An event record.
+
         """
         for _, value in record.items():
             self._buffer.append(repr(value))

--- a/cloudmarker/clouds/azcloud.py
+++ b/cloudmarker/clouds/azcloud.py
@@ -43,6 +43,7 @@ class AzCloud:
                 data for if the value is greater than 0.
             _max_recs (int): Maximum number of records of each type to
                 fetch under each subscription.
+
         """
         self._credentials = ServicePrincipalCredentials(
             tenant=tenant,
@@ -228,7 +229,7 @@ def _get_record(iterator, azure_record_type, max_recs,
         iterator: An iterator like instance of
             :class:`msrest.serialization.Model` objects.
         azure_record_type (str): Type of record as per Azure vocabulary.
-        _max_recs (int): Maximum number of records to fetch.
+        max_recs (int): Maximum number of records to fetch.
         sub_index (int): Subscription index (for logging only).
         sub (Subscription): Azure subscription model object.
         tenant (str): Azure tenant ID (for logging only).

--- a/cloudmarker/clouds/azsql.py
+++ b/cloudmarker/clouds/azsql.py
@@ -38,6 +38,7 @@ class AzSQL:
                 data for if the value is greater than 0.
             _max_recs (int): Maximum number of SQL server records
                 to fetch for each subscription.
+
         """
         self._credentials = ServicePrincipalCredentials(
             tenant=tenant,

--- a/cloudmarker/clouds/azvm.py
+++ b/cloudmarker/clouds/azvm.py
@@ -37,6 +37,7 @@ class AzVM:
                 data for if the value is greater than 0.
             _max_recs (int): Maximum number of virtual machines records
                 to fetch for each subscription.
+
         """
         self._credentials = ServicePrincipalCredentials(
             tenant=tenant,

--- a/cloudmarker/clouds/gcpcloud.py
+++ b/cloudmarker/clouds/gcpcloud.py
@@ -42,6 +42,7 @@ class GCPCloud:
             threads (int): Number of threads to launch in each process.
             _max_projects (int): Maximum number of projects to fetch
                 data for if the value is greater than 0.
+
         """
         self._key_file_path = key_file_path
         self._processes = processes
@@ -253,6 +254,7 @@ def _get_resource_iterator(resource, key, key_file_path, **list_kwargs):
         resource (Resource): GCP resource object.
         key (str): The key that we need to look up in the GCP
             response JSON to find the list of resources.
+        key_file_path (str): Path to key file (for logging only).
         list_kwargs (dict): Keyword arguments for
             ``resource.list()`` call.
 

--- a/cloudmarker/manager.py
+++ b/cloudmarker/manager.py
@@ -69,6 +69,7 @@ def _run(config):
 
     Arguments:
         config (dict): Configuration dictionary.
+
     """
     start_time = time.localtime()
     _send_email(config.get('email'), 'all audits', start_time)
@@ -117,6 +118,7 @@ class Audit:
                 entire configuration dictionary that contains
                 top-level keys named ``clouds``, ``stores``, ``events``,
                 ``alerts``, ``audits``, ``run``, etc.
+
         """
         self._start_time = time.localtime()
         self._audit_key = audit_key
@@ -278,6 +280,7 @@ def _send_email(email_config, about, start_time, end_time=None):
         end_time (time.struct_time): End time of job or audit. This
             argument must not be specified if the job or audit is
             starting.
+
     """
     state = 'starting' if end_time is None else 'ending'
     if email_config is None:

--- a/cloudmarker/stores/mongodbstore.py
+++ b/cloudmarker/stores/mongodbstore.py
@@ -29,6 +29,7 @@ class MongoDBStore:
             username (str): username for the database
             password (str): password for username to authenticate with the db
             buffer_size (int): maximum number of records to buffer
+
         """
         self._client = MongoClient(
             host=host,

--- a/cloudmarker/stores/splunkhecstore.py
+++ b/cloudmarker/stores/splunkhecstore.py
@@ -22,6 +22,7 @@ class SplunkHECStore:
             of host in URI, or False to disable verification
           buffer_size (int): Maximum number of records to hold in
             in-memory buffer for each record type.
+
         """
         self._uri = uri
         self._token = token

--- a/cloudmarker/test/test_filestore.py
+++ b/cloudmarker/test/test_filestore.py
@@ -15,6 +15,7 @@ def write_to_file(filename):
 
     Arguments:
         filename (str): the file location where dummy data has to be written
+
     """
     # Initialize the FileStore plugin with the filename
     store = filestore.FileStore(filename)

--- a/cloudmarker/util.py
+++ b/cloudmarker/util.py
@@ -194,7 +194,9 @@ def wrap_paragraphs(text, width=70):
     Finally, each paragraph is wrapped to the specified ``width``.
 
     Arguments:
+        text (str): String containing paragraphs to be wrapped.
         width (int): Maximum length of wrapped lines.
+
     """
     # Remove any common leading indentation from all lines.
     text = textwrap.dedent(text).strip()
@@ -388,10 +390,12 @@ def friendly_list(items, conjunction='and'):
 
     Arguments:
         items (list): List of items.
+        conjunction (str): Conjunction to be used before the last item
+            in the list; ``'and'`` by default.
 
     Returns:
         str: Human-friendly list of items with correct placement of
-            comma and conjunction.
+        comma and conjunction.
 
     """
     if not items:
@@ -544,6 +548,7 @@ def send_email(from_addr, to_addrs, subject, content,
             ``0`` (the default) or ``False`` to disable debugging. Set
             to ``1`` or ``True`` to see SMTP messages. Set to ``2`` to
             see timestamped SMTP messages.
+
     """
     log_data = ('from_addr: {}; to_addrs: {}; subject: {}; host: {}; '
                 'port: {}; ssl_mode: {}'

--- a/cloudmarker/workers.py
+++ b/cloudmarker/workers.py
@@ -34,6 +34,7 @@ def cloud_worker(audit_key, audit_version, plugin_key, plugin_config,
         plugin_config (dict): Cloud plugin config dictionary.
         output_queues (list): List of :class:`multiprocessing.Queue`
             objects to write records to.
+
     """
     worker_name = audit_key + '_' + plugin_key
     _log.info('cloud_worker: %s: Started', worker_name)
@@ -89,6 +90,7 @@ def event_worker(audit_key, audit_version, plugin_key, plugin_config,
         input_queue (multiprocessing.Queue): Queue to read records from.
         output_queues (list): List of :class:`multiprocessing.Queue`
             objects to write records to.
+
     """
     worker_name = audit_key + '_' + plugin_key
     _log.info('event_worker: %s: Started', worker_name)
@@ -154,6 +156,7 @@ def store_worker(audit_key, audit_version, plugin_key, plugin_config,
         plugin_key (str): Plugin key name in configuration.
         plugin_config (dict): Store plugin config dictionary.
         input_queue (multiprocessing.Queue): Queue to read records from.
+
     """
     _write_worker(audit_key, audit_version, plugin_key, plugin_config,
                   input_queue, 'store')
@@ -172,6 +175,7 @@ def alert_worker(audit_key, audit_version, plugin_key, plugin_config,
         plugin_key (str): Plugin key name in configuration.
         plugin_config (dict): Alert plugin config dictionary.
         input_queue (multiprocessing.Queue): Queue to read records from.
+
     """
     _write_worker(audit_key, audit_version, plugin_key, plugin_config,
                   input_queue, 'alert')
@@ -186,7 +190,9 @@ def _write_worker(audit_key, audit_version, plugin_key, plugin_config,
         audit_version (str): Audit version string.
         plugin_key (str): Plugin key name in configuration.
         plugin_config (dict): Store or alert plugin config dictionary.
+        input_queue (multiprocessing.Queue): Queue to read records from.
         worker_type (str): Either ``'store'`` or ``'alert'``.
+
     """
     worker_name = audit_key + '_' + plugin_key
     _log.info('%s_worker: %s: Started', worker_type, worker_name)


### PR DESCRIPTION
The latest release of pydocstyle (version 4.0.0) reports more
errors than the previous release (version 3.0.0). A few examples of
these additional errors are:

    D413 Missing blank line after last section ('Arguments') [pydocstyle]
    D417 Missing arguments in the function docstring (argument(s) 'text'
    missing in function 'wrap_paragraphs' docstring) [pydocstyle]

This change fixes these new errors.