### PR TITLE
Update indentation in API docs source files

### DIFF
--- a/docs/api/cloudmarker.alerts.rst
+++ b/docs/api/cloudmarker.alerts.rst
@@ -2,9 +2,9 @@ cloudmarker.alerts package
 ==========================
 
 .. automodule:: cloudmarker.alerts
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 Submodules
 ----------
@@ -13,16 +13,15 @@ cloudmarker.alerts.emailalert module
 ------------------------------------
 
 .. automodule:: cloudmarker.alerts.emailalert
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 cloudmarker.alerts.slackalert module
 ------------------------------------
 
 .. automodule:: cloudmarker.alerts.slackalert
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
+   :members:
+   :undoc-members:
+   :show-inheritance:
 

--- a/docs/api/cloudmarker.clouds.rst
+++ b/docs/api/cloudmarker.clouds.rst
@@ -2,9 +2,9 @@ cloudmarker.clouds package
 ==========================
 
 .. automodule:: cloudmarker.clouds
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 Submodules
 ----------
@@ -13,40 +13,39 @@ cloudmarker.clouds.azcloud module
 ---------------------------------
 
 .. automodule:: cloudmarker.clouds.azcloud
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 cloudmarker.clouds.azsql module
 -------------------------------
 
 .. automodule:: cloudmarker.clouds.azsql
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 cloudmarker.clouds.azvm module
 ------------------------------
 
 .. automodule:: cloudmarker.clouds.azvm
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 cloudmarker.clouds.gcpcloud module
 ----------------------------------
 
 .. automodule:: cloudmarker.clouds.gcpcloud
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 cloudmarker.clouds.mockcloud module
 -----------------------------------
 
 .. automodule:: cloudmarker.clouds.mockcloud
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
+   :members:
+   :undoc-members:
+   :show-inheritance:
 

--- a/docs/api/cloudmarker.events.rst
+++ b/docs/api/cloudmarker.events.rst
@@ -2,59 +2,58 @@ cloudmarker.events package
 ==========================
 
 .. automodule:: cloudmarker.events
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 Submodules
 ----------
 
-cloudmarker.events.azsqldatabasedisabledtdeevent module
--------------------------------------------------------
+cloudmarker.events.azsqldatabasetdeevent module
+-----------------------------------------------
 
-.. automodule:: cloudmarker.events.azsqldatabasedisabledtdeevent
-    :members:
-    :undoc-members:
-    :show-inheritance:
+.. automodule:: cloudmarker.events.azsqldatabasetdeevent
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 cloudmarker.events.azvmdatadiskencryptionevent module
 -----------------------------------------------------
 
 .. automodule:: cloudmarker.events.azvmdatadiskencryptionevent
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 cloudmarker.events.azvmosdiskencryptionevent module
 ---------------------------------------------------
 
 .. automodule:: cloudmarker.events.azvmosdiskencryptionevent
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 cloudmarker.events.firewallruleevent module
 -------------------------------------------
 
 .. automodule:: cloudmarker.events.firewallruleevent
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 cloudmarker.events.mockevent module
 -----------------------------------
 
 .. automodule:: cloudmarker.events.mockevent
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 cloudmarker.events.rdbmsenforcetlsevent module
 ----------------------------------------------
 
 .. automodule:: cloudmarker.events.rdbmsenforcetlsevent
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
+   :members:
+   :undoc-members:
+   :show-inheritance:
 

--- a/docs/api/cloudmarker.rst
+++ b/docs/api/cloudmarker.rst
@@ -2,19 +2,19 @@ cloudmarker package
 ===================
 
 .. automodule:: cloudmarker
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 Subpackages
 -----------
 
 .. toctree::
 
-    cloudmarker.alerts
-    cloudmarker.clouds
-    cloudmarker.events
-    cloudmarker.stores
+   cloudmarker.alerts
+   cloudmarker.clouds
+   cloudmarker.events
+   cloudmarker.stores
 
 Submodules
 ----------
@@ -23,40 +23,39 @@ cloudmarker.baseconfig module
 -----------------------------
 
 .. automodule:: cloudmarker.baseconfig
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 cloudmarker.ioworkers module
 ----------------------------
 
 .. automodule:: cloudmarker.ioworkers
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 cloudmarker.manager module
 --------------------------
 
 .. automodule:: cloudmarker.manager
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 cloudmarker.util module
 -----------------------
 
 .. automodule:: cloudmarker.util
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 cloudmarker.workers module
 --------------------------
 
 .. automodule:: cloudmarker.workers
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
+   :members:
+   :undoc-members:
+   :show-inheritance:
 

--- a/docs/api/cloudmarker.stores.rst
+++ b/docs/api/cloudmarker.stores.rst
@@ -2,9 +2,9 @@ cloudmarker.stores package
 ==========================
 
 .. automodule:: cloudmarker.stores
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 Submodules
 ----------
@@ -13,32 +13,31 @@ cloudmarker.stores.esstore module
 ---------------------------------
 
 .. automodule:: cloudmarker.stores.esstore
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 cloudmarker.stores.filestore module
 -----------------------------------
 
 .. automodule:: cloudmarker.stores.filestore
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 cloudmarker.stores.mongodbstore module
 --------------------------------------
 
 .. automodule:: cloudmarker.stores.mongodbstore
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 cloudmarker.stores.splunkhecstore module
 ----------------------------------------
 
 .. automodule:: cloudmarker.stores.splunkhecstore
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
+   :members:
+   :undoc-members:
+   :show-inheritance:
 


### PR DESCRIPTION
The indentation style in API documentation source files generated by the
latest version of `sphinx-apidoc` has changed. With the earlier Sphinx
2.0.1, the automodule directives were indented as follows:

	.. automodule:: cloudmarker.alerts
		:members:
		:undoc-members:
		:show-inheritance:

Since Sphinx 2.1.0 and later, they are now indented as follows:

	.. automodule:: cloudmarker.alerts
	   :members:
	   :undoc-members:
	   :show-inheritance:

This change updates the Sphinx project's source code files with this
updated indentation style, so that subsequent running of `sphinx-apidoc`
does not lead to diffs due to indentation changes.