### PR TITLE
Make TLS version configurable in AzWebAppTLSEvent

### DIFF
--- a/cloudmarker/events/azwebapptlsevent.py
+++ b/cloudmarker/events/azwebapptlsevent.py
@@ -1,8 +1,8 @@
 """Microsoft web app minimum TLS version event.
 
 This module defines the :class:`AzWebAppTLSEvent` class that identifies
-a web app with minimum TLS version not equal to the latest version
-(1.2). This plugin works on the web apps config properties found in the
+a web app with minimum TLS version not equal to the required minimum TLS
+version. This plugin works on the web apps config properties found in the
 ``com`` bucket of ``web_app`` records.
 """
 
@@ -17,8 +17,16 @@ _log = logging.getLogger(__name__)
 class AzWebAppTLSEvent:
     """Azure web app minimum TLS version check event plugin."""
 
-    def __init__(self):
-        """Create an instance of :class:`AzWebAppTLSEvent`."""
+    def __init__(self, _min_tls_version=1.2):
+        """Create an instance of :class:`AzWebAppTLSEvent`.
+
+        Arguments:
+            _min_tls_version (float): Minimum required TLS version.
+
+        """
+        self._min_tls_version = _min_tls_version
+        _log.info("Initialized; minimum TLS version: %.1f",
+                  self._min_tls_version)
 
     def eval(self, record):
         """Evaluate Azure web app to check for insecure TLS config.
@@ -41,9 +49,9 @@ class AzWebAppTLSEvent:
 
         min_tls_version = ext.get('min_tls_version')
 
-        if min_tls_version != '1.2':
+        if float(min_tls_version) < self._min_tls_version:
             yield from _get_azure_web_app_tls_event(
-                com, ext)
+                com, ext, self._min_tls_version)
 
     def done(self):
         """Perform cleanup work.
@@ -52,17 +60,17 @@ class AzWebAppTLSEvent:
         """
 
 
-def _get_azure_web_app_tls_event(com, ext):
+def _get_azure_web_app_tls_event(com, ext, min_tls_version):
     """Evaluate Azure web app config for insecure min TLS version.
 
     Arguments:
         com (dict): Azure web app record `com` bucket
         ext (dict): Azure web app record `ext` bucket
-        raw (dict): Azure web app record `raw` bucket
+        min_tls_version (float): Minimum required TLS version
 
     Returns:
         dict: An event record representing web apps not using a minimum
-        TLS version of 1.2
+        TLS version
 
     """
     friendly_cloud_type = util.friendly_string(com.get('cloud_type'))
@@ -72,8 +80,8 @@ def _get_azure_web_app_tls_event(com, ext):
         .format(friendly_cloud_type, reference)
     )
     recommendation = (
-        'Check {} web app {} and ensure the minimum TLS version is set to 1.2.'
-        .format(friendly_cloud_type, reference)
+        'Check {} web app {} and ensure the minimum TLS version is set to {}.'
+        .format(friendly_cloud_type, reference, str(min_tls_version))
     )
 
     event_record = {


### PR DESCRIPTION
`AzWebAppTLSEvent` event plugin evaluates Azure web apps and generate an
event if the miniumum TLS version is less than required minimum TLS
version. Currently, required minimum TLS version has been hardcoded to
1.2, with this change it will be possible to configure the required
minimum TLS version through configuration file.

This also addresses the following issue [#154](https://github.com/cloudmarker/cloudmarker/pull/154)

Resolves: #154 