### PR TITLE
Add AzLogProfileMissingCategoryEvent plugin

### DIFF
--- a/cloudmarker/events/azlogprofilemissingcategoryevent.py
+++ b/cloudmarker/events/azlogprofilemissingcategoryevent.py
@@ -1,0 +1,123 @@
+"""Microsoft Azure Log Profile Missing Category Type Event.
+
+This module defines the :class:`AzLogProfileMissingCategoryEvent` class
+that identifies if a log profile which is not enable for all the categories
+i.e. Write, Delete and Action. This plugin works on the log profile
+properties found in the ``raw`` bucket of ``log_profile`` records.
+"""
+
+
+import logging
+
+from cloudmarker import util
+
+_log = logging.getLogger(__name__)
+
+
+class AzLogProfileMissingCategoryEvent:
+    """Azure log profile missing category event plugin."""
+
+    def __init__(self):
+        """Create an instance of the class.
+
+        Create an instance of the
+        :class:`AzLogProfileMissingCategoryEvent`.
+        """
+
+    def eval(self, record):
+        """Evaluate Azure log profiles for enabled categories.
+
+        Arguments:
+            record (dict): An Azure log profile record.
+
+        Yields:
+            dict: An event record representing an Azure log profile
+            which is not enabled for all categories.
+
+        """
+        com = record.get('com', {})
+        if com is None:
+            return
+
+        if com.get('cloud_type') != 'azure':
+            return
+
+        if com.get('record_type') != 'log_profile':
+            return
+
+        ext = record.get('ext', {})
+        if ext is None:
+            return
+
+        raw = record.get('raw', {})
+        if raw is None:
+            return
+        yield from _evaluate_log_profile_for_categories(com, ext, raw)
+
+    def done(self):
+        """Perform cleanup work.
+
+        Currently, this method does nothing. This may change in future.
+        """
+
+
+def _evaluate_log_profile_for_categories(com, ext, raw):
+    """Evaluate log profile for missing caegories.
+
+    Arguments:
+        com (dict): Log profile record `com` bucket
+        ext (dict): Log profile record `ext` bucket
+        raw (dict): Log profile record `raw` bucket
+    Yields:
+        dict: An event record representing a log profile which is not enabled
+              for all categories.
+
+    """
+    categories = set(('Write', 'Delete', 'Action'))
+    missing_categories = categories - set(raw.get('categories'))
+    if not missing_categories:
+        return
+    yield _get_log_profile_missing_category_event(com, ext, missing_categories)
+
+
+def _get_log_profile_missing_category_event(com, ext, missing_categories):
+    """Generate log profile missing category type event.
+
+    Arguments:
+        com (dict): Log profile record `com` bucket
+        ext (dict): Log profile record `ext` bucket
+        missing_categories (set): Missing activity set
+    Returns:
+        dict: An event record representing log profile with missing categories.
+
+    """
+    friendly_cloud_type = util.friendly_string(com.get('cloud_type'))
+    reference = com.get('reference')
+    description = (
+        '{} log profile {} does not include categories {}.'
+        .format(friendly_cloud_type, reference,
+                util.friendly_list(missing_categories))
+    )
+    recommendation = (
+        'Check {} log profile {} and enable categories {}.'
+        .format(friendly_cloud_type, reference,
+                util.friendly_list(missing_categories))
+    )
+    event_record = {
+        # Preserve the extended properties from the log profile
+        # record because they provide useful context to locate
+        # the log profile that led to the event.
+        'ext': util.merge_dicts(ext, {
+            'record_type': 'log_profile_missing_category_event'
+        }),
+        'com': {
+            'cloud_type': com.get('cloud_type'),
+            'record_type': 'log_profile_missing_category_event',
+            'reference': reference,
+            'description': description,
+            'recommendation': recommendation,
+        }
+    }
+    _log.info('Generating log_profile_missing_category_event; %r',
+              event_record)
+    return event_record

--- a/cloudmarker/test/test_azlogprofilemissingcategoryevent.py
+++ b/cloudmarker/test/test_azlogprofilemissingcategoryevent.py
@@ -1,0 +1,89 @@
+"""Tests for AzLogProfileMissingCategoryEvent plugin."""
+
+
+import copy
+import unittest
+
+from cloudmarker.events import azlogprofilemissingcategoryevent
+
+base_log_profile_id = '/subscriptions/foo_sub_id/providers/\
+                    microsoft.insights/logprofiles/foo_lp_name'
+
+base_record = {
+    'com':  {
+        'cloud_type':  'azure',
+        'record_type': 'log_profile',
+        'reference': base_log_profile_id,
+    },
+    'ext': {
+        'reference': base_log_profile_id,
+    },
+    'raw': {
+        'categories': [],
+    }
+}
+
+
+class AzLogProfileMissingCategoryEventTest(unittest.TestCase):
+    """Tests for AzLogProfileMissingCategoryEvent plugin."""
+
+    def test_com_bucket_missing(self):
+        record = copy.deepcopy(base_record)
+        record['com'] = None
+        plugin = azlogprofilemissingcategoryevent. \
+            AzLogProfileMissingCategoryEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_com_bucket_cloud_type_non_azure(self):
+        record = copy.deepcopy(base_record)
+        record['com']['cloud_type'] = 'non_azure'
+        plugin = azlogprofilemissingcategoryevent. \
+            AzLogProfileMissingCategoryEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_com_bucket_record_type_non_log_profile(self):
+        record = copy.deepcopy(base_record)
+        record['com']['record_type'] = 'non_log_profile'
+        plugin = azlogprofilemissingcategoryevent. \
+            AzLogProfileMissingCategoryEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_ext_bucket_missing(self):
+        record = copy.deepcopy(base_record)
+        record['ext'] = None
+        plugin = azlogprofilemissingcategoryevent. \
+            AzLogProfileMissingCategoryEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_raw_bucket_missing(self):
+        record = copy.deepcopy(base_record)
+        record['raw'] = None
+        plugin = azlogprofilemissingcategoryevent. \
+            AzLogProfileMissingCategoryEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_all_event_types_missing(self):
+        record = copy.deepcopy(base_record)
+        plugin = azlogprofilemissingcategoryevent. \
+            AzLogProfileMissingCategoryEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(len(events), 1)
+
+    def test_single_event_types_missing(self):
+        record = copy.deepcopy(base_record)
+        record['raw']['categories'] = ['Write', 'Delete']
+        plugin = azlogprofilemissingcategoryevent. \
+            AzLogProfileMissingCategoryEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0]['ext']['record_type'],
+                         'log_profile_missing_category_event')
+        self.assertEqual(events[0]['com']['record_type'],
+                         'log_profile_missing_category_event')
+        self.assertEqual(events[0]['com']['cloud_type'], 'azure')
+        self.assertEqual(events[0]['com']['reference'], base_log_profile_id)

--- a/docs/api/cloudmarker.clouds.rst
+++ b/docs/api/cloudmarker.clouds.rst
@@ -17,6 +17,14 @@ cloudmarker.clouds.azcloud module
    :undoc-members:
    :show-inheritance:
 
+cloudmarker.clouds.azmonitor module
+-----------------------------------
+
+.. automodule:: cloudmarker.clouds.azmonitor
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 cloudmarker.clouds.azsql module
 -------------------------------
 

--- a/docs/api/cloudmarker.events.rst
+++ b/docs/api/cloudmarker.events.rst
@@ -9,6 +9,14 @@ cloudmarker.events package
 Submodules
 ----------
 
+cloudmarker.events.azlogprofilemissingcategoryevent module
+----------------------------------------------------------
+
+.. automodule:: cloudmarker.events.azlogprofilemissingcategoryevent
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 cloudmarker.events.azsqldatabasetdeevent module
 -----------------------------------------------
 

--- a/pylama.ini
+++ b/pylama.ini
@@ -140,3 +140,8 @@ ignore = R0913,W0703
 
 # R0913 Too many arguments (8/5) [pylint]
 # W0703 Catching too general exception Exception [pylint]
+
+[pylama:cloudmarker/events/azlogprofilemissingcategoryevent.py]
+ignore = R0201
+
+# R0201 Method could be a function [pylint]


### PR DESCRIPTION
A log profile controls how the activity log is exported. Configure the
log profile to collect logs for the categories `write`, `delete` and
`action` ensures that all the control/management plane activities
performed on the subscription are exported.

The `AzLogProfileMissingCategoryEvent` plugin evaluates records of
type `log_profile` for Azure cloud and generates event of type
`log_profile_missing_category_event` if a log profile is not
enabled for all three activity types i.e. `Write`, `Delete` and
`Action`.