### PR TITLE
Add AzLogProfileRetentionEvent plugin

### DIFF
--- a/cloudmarker/baseconfig.py
+++ b/cloudmarker/baseconfig.py
@@ -56,6 +56,9 @@ plugins:
   azstorageaccountsecuretransferevent:
     plugin: cloudmarker.events.azstorageaccountsecuretransferevent.AzStorageAccountSecureTransferEvent
 
+  azlogprofileretentionevent:
+    plugin: cloudmarker.events.azlogprofileretentionevent.AzLogProfileRetentionEvent
+
   mockevent:
     plugin: cloudmarker.events.mockevent.MockEvent
 

--- a/cloudmarker/clouds/azmonitor.py
+++ b/cloudmarker/clouds/azmonitor.py
@@ -209,9 +209,18 @@ def _get_record(iterator, attribute_type, max_recs,
         _log.info('Found %s #%d: %s; %s', attribute_type, i,
                   raw_record.get('name'),
                   util.outline_az_sub(sub_index, sub, tenant))
-
+        retention_policy = raw_record.get('retention_policy')
         record = util.merge_dicts(base_record, {
             'raw': raw_record,
+            'ext': {
+                'cloud_type': 'azure',
+                'record_type': attribute_type,
+                'subscription_id': sub.get('subscription_id'),
+                'subscription_name': sub.get('display_name'),
+                'subscription_state': sub.get('state'),
+                'retention_enabled': retention_policy.get('enabled'),
+                'retention_days': retention_policy.get('days'),
+            },
             'com': {
                 'reference': raw_record.get('id'),
             }

--- a/cloudmarker/events/azlogprofileretentionevent.py
+++ b/cloudmarker/events/azlogprofileretentionevent.py
@@ -1,0 +1,113 @@
+"""Microsoft Azure Log Profile Retention Event.
+
+This module defines the :class:`AzLogProfileRetentionEvent` class that
+identifies if an Azure log profile's retention policy is configured for
+less than the minimum number of days than required. This plugin works
+properties found in the ``ext`` bucket of ``log_profile`` records.
+"""
+
+
+import logging
+
+from cloudmarker import util
+
+_log = logging.getLogger(__name__)
+
+
+class AzLogProfileRetentionEvent:
+    """Azure log profile retention event plugin."""
+
+    def __init__(self, _min_retention_days=365):
+        """Create an instance of :class:`AzLogProfileRetentionEvent`.
+
+        Arguments:
+            _min_retention_days (int): Minimum required
+                                    retention days.
+
+        """
+        self._min_retention_days = _min_retention_days
+        _log.info("Initialized; minimum retention days: %d",
+                  self._min_retention_days)
+
+    def eval(self, record):
+        """Evaluate Azure log profiles for retention policy.
+
+        Arguments:
+            record (dict): An Azure log profile record.
+
+        Yields:
+            dict: An event record representing an Azure log profile
+            with retention set to less than the required days.
+
+        """
+        com = record.get('com', {})
+        if com is None:
+            return
+
+        if com.get('cloud_type') != 'azure':
+            return
+
+        if com.get('record_type') != 'log_profile':
+            return
+
+        ext = record.get('ext', {})
+        if ext is None:
+            return
+
+        if ext['retention_enabled']:
+            if ext['retention_days'] < self._min_retention_days:
+                yield from _get_log_profile_retention_event(
+                    com, ext, self._min_retention_days)
+        else:
+            if ext['retention_days'] != 0:
+                yield from _get_log_profile_retention_event(
+                    com, ext, self._min_retention_days)
+
+    def done(self):
+        """Perform cleanup work.
+
+        Currently, this method does nothing. This may change in future.
+        """
+
+
+def _get_log_profile_retention_event(com, ext, min_retention_days):
+    """Generate log profile retention event.
+
+    Arguments:
+        com (dict): Log profile record `com` bucket
+        ext (dict): Log profile record `ext` bucket
+        min_retention_days (int): Minimum required retention days.
+
+    Returns:
+        dict: An event record representing log profile with retention
+             policy configured for less number of days than required.
+
+    """
+    friendly_cloud_type = util.friendly_string(com.get('cloud_type'))
+    reference = com.get('reference')
+    description = (
+        '{} log profile {} has log retention set to less than {} days.'
+        .format(friendly_cloud_type, reference, min_retention_days)
+    )
+    recommendation = (
+        'Check {} log profile {} and set log retention to more than {} days.'
+        .format(friendly_cloud_type, reference, min_retention_days)
+    )
+    event_record = {
+        # Preserve the extended properties from the virtual
+        # machine record because they provide useful context to
+        # locate the virtual machine that led to the event.
+        'ext': util.merge_dicts(ext, {
+            'record_type': 'log_profile_retention_event'
+        }),
+        'com': {
+            'cloud_type': com.get('cloud_type'),
+            'record_type': 'log_profile_retention_event',
+            'reference': reference,
+            'description': description,
+            'recommendation': recommendation,
+        }
+    }
+
+    _log.info('Generating log_profile_retention_event; %r', event_record)
+    yield event_record

--- a/cloudmarker/test/test_azmonitor.py
+++ b/cloudmarker/test/test_azmonitor.py
@@ -12,17 +12,26 @@ base_sub_display_name = 'foo_display_name'
 
 base_sub_state = 'foo_state'
 
+base_retention_days = 365
+
+base_retention_enabled = True
+
 base_subscription_record = {
     'subscription_id': base_sub_id,
     'display_name': base_sub_display_name,
     'state': base_sub_state
 }
 
+base_retention_policy = {
+    'days': base_retention_days,
+    'enabled': base_retention_enabled,
+}
 base_log_profile_id = '/subscriptions/foo_sub_id/providers/\
                     microsoft.insights/logprofiles/foo_lp_name'
 
 base_log_profile = {
-    'id': base_log_profile_id
+    'id': base_log_profile_id,
+    'retention_policy': base_retention_policy,
 }
 
 
@@ -75,6 +84,10 @@ class AzSQLTest(unittest.TestCase):
         self.assertEqual(records[0]['ext']['subscription_id'], base_sub_id)
         self.assertEqual(records[0]['ext']['subscription_name'],
                          base_sub_display_name)
+        self.assertTrue(records[0]['ext']['retention_enabled'],
+                        base_retention_enabled)
+        self.assertEqual(records[0]['ext']['retention_days'],
+                         base_retention_days)
         self.assertEqual(records[0]['ext']['subscription_state'],
                          base_sub_state)
         self.assertEqual(records[0]['com']['cloud_type'], 'azure')


### PR DESCRIPTION
The `AzLogProfileRetentionEvent` plugin evaluate an Azure `log_profile`
record and generate and event of type `log_profile_retention_event` if
the log profile's retention policy is configured for less number of days
than required. The default value for minumum number of days is 365, as
per CIS recommendation but can be changed to any other desired value
through the `min_retention_days` parameter.

It is to be noted that setting retention (days) to 0 from portal
sets days to 0 and enabled to false, which will retain the data forever.