### PR TITLE
Add Azure Key Vault plugins

### DIFF
--- a/cloudmarker/baseconfig.py
+++ b/cloudmarker/baseconfig.py
@@ -59,6 +59,12 @@ plugins:
   azlogprofileretentionevent:
     plugin: cloudmarker.events.azlogprofileretentionevent.AzLogProfileRetentionEvent
 
+  azkeyvaultsecretnoexpiryevent:
+    plugin: cloudmarker.events.azkvsecretnoexpiryevent.AzKVSecretNoExpiryEvent
+
+  azkeyvaultkeynoexpiryevent:
+    plugin: cloudmarker.events.azkeyvaultkeynoexpiryevent.AzKeyVaultKeyNoExpiryEvent
+
   mockevent:
     plugin: cloudmarker.events.mockevent.MockEvent
 

--- a/cloudmarker/baseconfig.py
+++ b/cloudmarker/baseconfig.py
@@ -65,6 +65,9 @@ plugins:
   azkeyvaultkeynoexpiryevent:
     plugin: cloudmarker.events.azkvkeynoexpiryevent.AzKVKeyNoExpiryEvent
 
+  azkvnonrecoverableevent:
+    plugin: cloudmarker.events.azkvnonrecoverableevent.AzKVNonRecoverableEvent
+
   mockevent:
     plugin: cloudmarker.events.mockevent.MockEvent
 

--- a/cloudmarker/baseconfig.py
+++ b/cloudmarker/baseconfig.py
@@ -63,7 +63,7 @@ plugins:
     plugin: cloudmarker.events.azkvsecretnoexpiryevent.AzKVSecretNoExpiryEvent
 
   azkeyvaultkeynoexpiryevent:
-    plugin: cloudmarker.events.azkeyvaultkeynoexpiryevent.AzKeyVaultKeyNoExpiryEvent
+    plugin: cloudmarker.events.azkvkeynoexpiryevent.AzKVKeyNoExpiryEvent
 
   mockevent:
     plugin: cloudmarker.events.mockevent.MockEvent

--- a/cloudmarker/clouds/azkv.py
+++ b/cloudmarker/clouds/azkv.py
@@ -1,0 +1,304 @@
+"""Microsoft Azure Key Vault plugin to read Key Vault and associated resources.
+
+This module defines the :class:`AzKV` class that retrieves Key Vault
+from Microsoft Azure. This module also retrieves the keys and secret
+attributes stored within a Key Vault.
+"""
+
+
+import itertools
+import logging
+
+from azure.common.credentials import ServicePrincipalCredentials
+from azure.keyvault import KeyVaultAuthentication, KeyVaultClient
+from azure.keyvault.models import KeyVaultErrorException
+from azure.mgmt.keyvault import KeyVaultManagementClient
+from azure.mgmt.resource import SubscriptionClient
+from msrestazure import tools
+from msrestazure.azure_exceptions import CloudError
+
+from cloudmarker import ioworkers, util
+
+_log = logging.getLogger(__name__)
+
+
+class AzKV:
+    """Azure Key Vault plugin."""
+
+    def __init__(self, tenant, client, secret, processes=4, threads=30,
+                 _max_subs=0, _max_recs=0):
+        """Create an instance of :class:`AzKV` plugin.
+
+         Note: The ``_max_subs`` and ``_max_recs`` arguments should be
+         used only in the development-test-debug phase. They should not
+         be used in production environment. This is why we use the
+         convention of beginning their names with underscore.
+
+        Arguments:
+            tenant (str): Azure subscription tenant ID.
+            client (str): Azure service principal application ID.
+            secret (str): Azure service principal password.
+            _max_subs (int): Maximum number of subscriptions to fetch
+                data for if the value is greater than 0.
+            _max_recs (int): Maximum number of Key Vault records
+                to fetch for each subscription.
+
+        """
+        self._credentials = ServicePrincipalCredentials(
+            tenant=tenant,
+            client_id=client,
+            secret=secret,
+        )
+        self._key_vault_credentials = ServicePrincipalCredentials(
+            tenant=tenant,
+            client_id=client,
+            secret=secret,
+            resource="https://vault.azure.net",
+        )
+        self._tenant = tenant
+        self._processes = processes
+        self._threads = threads
+        self._max_subs = _max_subs
+        self._max_recs = _max_recs
+        _log.info('Initialized; tenant: %s; processes: %s; threads: %s',
+                  self._tenant, self._processes, self._threads)
+
+    def read(self):
+        """Return an Azure Key Vault record.
+
+        Yields:
+            dict: An Azure Key Vault and associated resource record.
+
+        """
+        yield from ioworkers.run(self._get_tenant_kvs,
+                                 self._process_key_vault,
+                                 self._processes, self._threads,
+                                 __name__)
+
+    def _get_tenant_kvs(self):
+        """Get Key Vaults from all subscriptions in a tenant.
+
+        The yielded tuples when unpacked would become arguments for
+        :meth:`_process_key_vault`. Each such tuple represents a
+        single unit of work that :meth:`_process_key_vault` can
+        work on independently in its own worker thread.
+
+        Yields:
+            tuple: A tuple which when unpacked forms valid arguments for
+                :meth:`_get_server_db_details`.
+
+        """
+        try:
+            tenant = self._tenant
+            creds = self._credentials
+            sub_client = SubscriptionClient(creds)
+            sub_list = sub_client.subscriptions.list()
+
+            for sub_index, sub in enumerate(sub_list):
+                sub = sub.as_dict()
+                _log.info('Found %s', util.outline_az_sub(sub_index,
+                                                          sub, tenant))
+
+                yield from self._get_subscription_kvs(sub_index, sub)
+                # Break after pulling data for self._max_subs number of
+                # subscriptions. Note that if self._max_subs is 0 or less,
+                # then the following condition never evaluates to True.
+                if sub_index + 1 == self._max_subs:
+                    _log.info('Stopping subscriptions fetch due to '
+                              '_max_subs: %d; tenant: %s', self._max_subs,
+                              tenant)
+                    break
+
+        except CloudError as e:
+            _log.error('Failed to fetch subscriptions; %s; error: %s: %s',
+                       util.outline_az_sub(sub_index, sub, tenant),
+                       type(e).__name__, e)
+
+    def _get_subscription_kvs(self, sub_index, sub):
+        """Get Key Vaults from a single subscrption.
+
+        Arguments:
+            sub_index (int): Subscription index (for logging only).
+            sub (Subscription): Azure subscription object.
+
+        Yields:
+            tuple: A tuple which when unpacked forms valid arguments for
+                :meth:`_process_key_vault`.
+
+        """
+        try:
+            tenant = self._tenant
+            creds = self._credentials
+            subscription_id = sub.get('subscription_id')
+            key_vault_mgmt_client = KeyVaultManagementClient(creds,
+                                                             subscription_id)
+            key_vault_list = key_vault_mgmt_client.vaults.list()
+
+            for key_vault_index, key_vault in enumerate(key_vault_list):
+                key_vault = key_vault.as_dict()
+                key_vault_name = key_vault.get('name')
+                key_vault_id = key_vault.get('id')
+                _log.info('Found Key Vault #%d: %s; %s',
+                          key_vault_index, key_vault_name,
+                          util.outline_az_sub(sub_index, sub, tenant))
+                rg_name = \
+                    tools.parse_resource_id(key_vault_id)['resource_group']
+
+                yield (key_vault_index, key_vault_name,
+                       rg_name, sub_index, sub)
+
+                # Break after pulling data for self._max_recs number
+                # of Key Vault for a subscriber. Note that if
+                # self._max_recs is 0 or less, then the following
+                # condition never evaluates to True.
+                if key_vault_index + 1 == self._max_recs:
+                    _log.info('Stopping Key Vault fetch due '
+                              'to _max_recs: %d; %s', self._max_recs,
+                              util.outline_az_sub(sub_index, sub,
+                                                  self._tenant))
+                    break
+        except CloudError as e:
+            _log.error('Failed to fetch Key Vault; %s; error: %s: %s',
+                       util.outline_az_sub(sub_index, sub, tenant),
+                       type(e).__name__, e)
+
+    def _process_key_vault(self, key_vault_index, key_vault_name, rg_name,
+                           sub_index, sub):
+        """Get details of Key Vault in management and data plane.
+
+        Arguments:
+            sub_index (int): Subscription index (for logging only).
+            sub (Subscription): Azure subscription object.
+            rg_name (str): Resource group name.
+            key_vault_index (int): Key Vault index (for logging only).
+            key_vault_name (str): Name of the Key Vault.
+
+        Yields:
+            dict: An Azure Key Vault server record.
+
+        """
+        def _auth_callback(server, resource, scope):
+            credentials = self._key_vault_credentials
+            token = credentials.token
+            return token['token_type'], token['access_token']
+
+        _log.info('Working on Key Vault #%d: %s; %s', key_vault_index,
+                  key_vault_name, util.outline_az_sub(sub_index, sub,
+                                                      self._tenant))
+        subscription_id = sub.get('subscription_id')
+        creds = self._credentials
+        key_vault_mgmt_client = KeyVaultManagementClient(creds,
+                                                         subscription_id)
+        key_vault_details = key_vault_mgmt_client.vaults.get(rg_name,
+                                                             key_vault_name)
+        yield from _get_normalized_key_vault_record(key_vault_details, sub)
+        try:
+            kv_client = \
+                KeyVaultClient(KeyVaultAuthentication(_auth_callback))
+
+            secrets = \
+                kv_client.get_secrets(key_vault_details.properties.vault_uri)
+
+            keys = \
+                kv_client.get_keys(key_vault_details.properties.vault_uri)
+
+            # Retrieve data using each iterator.
+            for record in itertools.chain(
+                    _get_data_record(secrets, 'key_vault_secret',
+                                     sub),
+                    _get_data_record(keys, 'key_vault_key',
+                                     sub),
+            ):
+                yield record
+
+        except CloudError as e:
+            _log.error('Failed to fetch key vault details; %s; error: %s: %s',
+                       util.outline_az_sub(sub_index, sub, self._tenant),
+                       type(e).__name__, e)
+
+    def done(self):
+        """Log a message that this plugin is done."""
+        _log.info('Done; tenant: %s; processes: %s; threads: %s',
+                  self._tenant, self._processes, self._threads)
+
+
+def _get_data_record(iterator, azure_record_type, sub):
+    """Normalize the Key Vault data plane record.
+
+    Arguments:
+        iterator: An iterator like instance of
+            :class:`msrest.serialization.Model` objects.
+        azure_record_type (str): Record type name.
+        sub (Subscription): Azure subscription object.
+
+    Returns:
+        dict: Normalized Key Vault data plane record.
+
+    """
+    subscription_id = sub.get('subscription_id')
+    try:
+        for i, v in enumerate(iterator):
+            raw_record = v.as_dict()
+            reference = raw_record.get('id')
+            if azure_record_type == 'key_vault_key':
+                reference = raw_record.get('kid')
+            expiry_set = raw_record['attributes'].get('expires') is not None
+            enabled = raw_record['attributes'].get('enabled')
+            record = {
+                'raw': raw_record,
+                'ext': {
+                    'cloud_type': 'azure',
+                    'expiry_set': expiry_set,
+                    'enabled': enabled,
+                    'record_type': azure_record_type,
+                    'reference': reference,
+                    'subscription_id': sub.get('subscription_id'),
+                    'subscription_name': sub.get('display_name'),
+                    'subscription_state': sub.get('state'),
+                },
+                'com': {
+                    'cloud_type': 'azure',
+                    'record_type': azure_record_type,
+                    'reference': reference,
+                }
+            }
+
+            _log.info('Found %s #%d; subscription_id: %s; name: %s',
+                      azure_record_type, i, sub.get('subscription_id'),
+                      reference)
+            yield record
+
+    except KeyVaultErrorException as e:
+        _log.error('Failed to fetch details for key_vault; '
+                   'subscription_id: %s; error: %s: %s',
+                   subscription_id, type(e).__name__, e)
+
+
+def _get_normalized_key_vault_record(key_vault_record, sub):
+    """Normalize the Key Vault details.
+
+    Arguments:
+        key_vault_record (dict): Raw Key Vault record.
+        sub (Subscription): Azure subscription object.
+
+    Returns:
+        dict: Normalized Key Vault details.
+
+    """
+    raw_record = key_vault_record.as_dict()
+    record = {
+        'raw': raw_record,
+        'ext': {
+            'cloud_type': 'azure',
+            'record_type': 'key_vault',
+            'subscription_id': sub.get('subscription_id'),
+            'subscription_name': sub.get('display_name'),
+            'subscription_state': sub.get('state'),
+        },
+        'com': {
+            'cloud_type': 'azure',
+            'record_type': 'key_vault',
+            'reference': raw_record.get('id', {}),
+        }
+    }
+    yield record

--- a/cloudmarker/clouds/azkv.py
+++ b/cloudmarker/clouds/azkv.py
@@ -286,11 +286,21 @@ def _get_normalized_key_vault_record(key_vault_record, sub):
 
     """
     raw_record = key_vault_record.as_dict()
+    enable_soft_delete = False
+    if raw_record['properties'].get('enable_soft_delete'):
+        enable_soft_delete = raw_record['properties'].get('enable_soft_delete')
+    enable_purge_protection = False
+    if raw_record['properties'].get('enable_purge_protection'):
+        enable_purge_protection = raw_record['properties']. \
+                                  get('enable_purge_protection')
     record = {
         'raw': raw_record,
         'ext': {
             'cloud_type': 'azure',
             'record_type': 'key_vault',
+            'enable_soft_delete': enable_soft_delete,
+            'enable_purge_protection': enable_purge_protection,
+            'recoverable': enable_purge_protection and enable_soft_delete,
             'subscription_id': sub.get('subscription_id'),
             'subscription_name': sub.get('display_name'),
             'subscription_state': sub.get('state'),

--- a/cloudmarker/events/azkvkeynoexpiryevent.py
+++ b/cloudmarker/events/azkvkeynoexpiryevent.py
@@ -1,0 +1,98 @@
+"""Microsoft Azure Key Vault key expiry event.
+
+This module defines the :class:`AzKVKeyNoExpiryEvent` class that
+identifies Key Vault keys without expiry set. This plugin works on the
+Key Vault key properties found in the ``ext`` bucket of ``key_vault_key``
+records.
+"""
+
+
+import logging
+
+from cloudmarker import util
+
+_log = logging.getLogger(__name__)
+
+
+class AzKVKeyNoExpiryEvent:
+    """Azure Key Vault key expiry event plugin."""
+
+    def __init__(self):
+        """Create an instance of :class:`AzKVKeyNoExpiryEvent`."""
+
+    def eval(self, record):
+        """Evaluate Azure Key Vault key for expiry date.
+
+        Arguments:
+            record (dict): A Key Vault key record.
+
+        Yields:
+            dict: An event record representing an Azure Key Vault keys
+            without expiry date.
+
+        """
+        com = record.get('com', {})
+        if com is None:
+            return
+
+        if com.get('cloud_type') != 'azure':
+            return
+
+        ext = record.get('ext', {})
+        if ext is None:
+            return
+
+        if ext.get('record_type') != 'key_vault_key':
+            return
+
+        if ext.get('enabled') and ext.get('expiry_set'):
+            return
+        yield from _get_key_vault_key_no_expiry_event(com, ext)
+
+    def done(self):
+        """Perform cleanup work.
+
+        Currently, this method does nothing. This may change in future.
+        """
+
+
+def _get_key_vault_key_no_expiry_event(com, ext):
+    """Generate Key Vault key expiry event.
+
+    Arguments:
+        com (dict): Key Vault key record `com` bucket.
+        ext (dict): Key Vault key record `ext` bucket.
+
+    Returns:
+        dict: An event record representing Key Vault key with no expiry
+        set.
+
+    """
+    friendly_cloud_type = util.friendly_string(com.get('cloud_type'))
+    reference = com.get('reference')
+    description = (
+        '{} Key Vault key {} has has no expiry set.'
+        .format(friendly_cloud_type, reference)
+    )
+    recommendation = (
+        'Check {} Key Vault key {} and set expiry.'
+        .format(friendly_cloud_type, reference)
+    )
+    event_record = {
+        # Preserve the extended properties from the key vault
+        # key record because they provide useful context to
+        # locate the key vault key that led to the event.
+        'ext': util.merge_dicts(ext, {
+            'record_type': 'key_vault_key_no_expiry_event'
+        }),
+        'com': {
+            'cloud_type': com.get('cloud_type'),
+            'record_type': 'key_vault_key_no_expiry_event',
+            'reference': reference,
+            'description': description,
+            'recommendation': recommendation,
+        }
+    }
+
+    _log.info('Generating key_vault_key_no_expiry_event; %r', event_record)
+    yield event_record

--- a/cloudmarker/events/azkvnonrecoverableevent.py
+++ b/cloudmarker/events/azkvnonrecoverableevent.py
@@ -1,0 +1,99 @@
+"""Microsoft Azure Key Vault non-recoverable event.
+
+This module defines the :class:`AzKVNonRecoverableEvent` class
+that identifies if a Key Vault is not recoverable. An Azure Key Vault
+is recoverable if both ``soft delete`` and ``purge protection`` is
+enabled. This plugin works on the Key Vault secret properties found
+in the ``ext`` bucket of ``key_vault`` records.
+"""
+
+
+import logging
+
+from cloudmarker import util
+
+_log = logging.getLogger(__name__)
+
+
+class AzKVNonRecoverableEvent:
+    """Azure Key Vault non-recoverable event plugin."""
+
+    def __init__(self):
+        """Create an instance of :class:`AzKVNonRecoverableEvent`."""
+
+    def eval(self, record):
+        """Evaluate if an Azure Key Vault is recoverable.
+
+        Arguments:
+            record (dict): A Key Vault record.
+
+        Yields:
+            dict: An event record representing an Azure Key Vault which is
+            not recoverable.
+
+        """
+        com = record.get('com', {})
+        if com is None:
+            return
+
+        if com.get('cloud_type') != 'azure':
+            return
+
+        ext = record.get('ext', {})
+        if ext is None:
+            return
+
+        if ext.get('record_type') != 'key_vault':
+            return
+
+        if ext.get('recoverable'):
+            return
+        yield from _get_key_vault_non_recoverable_event(com, ext)
+
+    def done(self):
+        """Perform cleanup work.
+
+        Currently, this method does nothing. This may change in future.
+        """
+
+
+def _get_key_vault_non_recoverable_event(com, ext):
+    """Generate Key Vault secret expiry event.
+
+    Arguments:
+        com (dict): Key Vault record `com` bucket.
+        ext (dict): Key Vault record `ext` bucket.
+
+    Returns:
+        dict: An event record representing Key Vault which is not
+        recoverable.
+
+    """
+    friendly_cloud_type = util.friendly_string(com.get('cloud_type'))
+    reference = com.get('reference')
+    description = (
+        '{} Key Vault {} is not recoverable.'
+        .format(friendly_cloud_type, reference)
+    )
+    recommendation = (
+        'Check {} Key Vault {} and enable purge protection and soft delete.'
+        .format(friendly_cloud_type, reference)
+    )
+    event_record = {
+        # Preserve the extended properties from the key vault
+        # record because they provide useful context to
+        # locate the key vault secret that led to the event.
+        'ext': util.merge_dicts(ext, {
+            'record_type': 'key_vault_non_recoverable_event'
+        }),
+        'com': {
+            'cloud_type': com.get('cloud_type'),
+            'record_type': 'key_vault_non_recoverable_event',
+            'reference': reference,
+            'description': description,
+            'recommendation': recommendation,
+        }
+    }
+
+    _log.info('Generating key_vault_non_recoverable_event; %r', event_record)
+    yield event_record

--- a/cloudmarker/events/azkvsecretnoexpiryevent.py
+++ b/cloudmarker/events/azkvsecretnoexpiryevent.py
@@ -1,0 +1,98 @@
+"""Microsoft Azure Key Vault secret expiry event.
+
+This module defines the :class:`AzKVSecretNoExpiryEvent` class that
+identifies if a Key Vault secret without expiry set. This plugin works on the
+Key Vault secret properties found in the ``ext`` bucket of ``key_vault_secret``
+records.
+"""
+
+
+import logging
+
+from cloudmarker import util
+
+_log = logging.getLogger(__name__)
+
+
+class AzKVSecretNoExpiryEvent:
+    """Azure Key Vault secret expiry event plugin."""
+
+    def __init__(self):
+        """Create an instance of :class:`AzKVSecretNoExpiryEvent`."""
+
+    def eval(self, record):
+        """Evaluate Azure Key Vault secret for expiry date.
+
+        Arguments:
+            record (dict): A Key Vault secret record.
+
+        Yields:
+            dict: An event record representing an Azure Key Vault secret
+            without expiry date.
+
+        """
+        com = record.get('com', {})
+        if com is None:
+            return
+
+        if com.get('cloud_type') != 'azure':
+            return
+
+        ext = record.get('ext', {})
+        if ext is None:
+            return
+
+        if ext.get('record_type') != 'key_vault_secret':
+            return
+
+        if ext.get('enabled') and ext.get('expiry_set'):
+            return
+        yield from _get_key_vault_secret_no_expiry_event(com, ext)
+
+    def done(self):
+        """Perform cleanup work.
+
+        Currently, this method does nothing. This may change in future.
+        """
+
+
+def _get_key_vault_secret_no_expiry_event(com, ext):
+    """Generate Key Vault secret expiry event.
+
+    Arguments:
+        com (dict): Key Vault secret record `com` bucket.
+        ext (dict): Key Vault secret record `ext` bucket.
+
+    Returns:
+        dict: An event record representing Key Vault secret with no expiry
+        set.
+
+    """
+    friendly_cloud_type = util.friendly_string(com.get('cloud_type'))
+    reference = com.get('reference')
+    description = (
+        '{} Key Vault secret {} has has no expiration date set.'
+        .format(friendly_cloud_type, reference)
+    )
+    recommendation = (
+        'Check {} Key Vault secret {} and set expiration date.'
+        .format(friendly_cloud_type, reference)
+    )
+    event_record = {
+        # Preserve the extended properties from the key vault
+        # secret record because they provide useful context to
+        # locate the key vault secret that led to the event.
+        'ext': util.merge_dicts(ext, {
+            'record_type': 'key_vault_secret_no_expiry_event'
+        }),
+        'com': {
+            'cloud_type': com.get('cloud_type'),
+            'record_type': 'key_vault_secret_no_expiry_event',
+            'reference': reference,
+            'description': description,
+            'recommendation': recommendation,
+        }
+    }
+
+    _log.info('Generating key_vault_secret_no_expiry_event; %r', event_record)
+    yield event_record

--- a/docs/api/cloudmarker.clouds.rst
+++ b/docs/api/cloudmarker.clouds.rst
@@ -17,6 +17,14 @@ cloudmarker.clouds.azcloud module
    :undoc-members:
    :show-inheritance:
 
+cloudmarker.clouds.azkv module
+------------------------------
+
+.. automodule:: cloudmarker.clouds.azkv
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 cloudmarker.clouds.azmonitor module
 -----------------------------------
 

--- a/docs/api/cloudmarker.events.rst
+++ b/docs/api/cloudmarker.events.rst
@@ -9,6 +9,30 @@ cloudmarker.events package
 Submodules
 ----------
 
+cloudmarker.events.azkvkeynoexpiryevent module
+----------------------------------------------
+
+.. automodule:: cloudmarker.events.azkvkeynoexpiryevent
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+cloudmarker.events.azkvnonrecoverableevent module
+-------------------------------------------------
+
+.. automodule:: cloudmarker.events.azkvnonrecoverableevent
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+cloudmarker.events.azkvsecretnoexpiryevent module
+-------------------------------------------------
+
+.. automodule:: cloudmarker.events.azkvsecretnoexpiryevent
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 cloudmarker.events.azlogprofileevent module
 -------------------------------------------
 
@@ -21,6 +45,22 @@ cloudmarker.events.azlogprofilemissingcategoryevent module
 ----------------------------------------------------------
 
 .. automodule:: cloudmarker.events.azlogprofilemissingcategoryevent
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+cloudmarker.events.azlogprofilemissinglocationevent module
+----------------------------------------------------------
+
+.. automodule:: cloudmarker.events.azlogprofilemissinglocationevent
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+cloudmarker.events.azlogprofileretentionevent module
+----------------------------------------------------
+
+.. automodule:: cloudmarker.events.azlogprofileretentionevent
    :members:
    :undoc-members:
    :show-inheritance:

--- a/pylama.ini
+++ b/pylama.ini
@@ -180,3 +180,8 @@ ignore = R0201
 ignore = R0201
 
 # R0201 Method could be a function [pylint]
+
+[pylama:cloudmarker/events/azkvnonrecoverableevent.py]
+ignore = R0201
+
+# R0201 Method could be a function [pylint]

--- a/pylama.ini
+++ b/pylama.ini
@@ -171,3 +171,8 @@ ignore = R0913,W0613,R0914
 # W0613 Unused argument 'scope' [pylint]
 # R0914 Too many local variables (17/15) [pylint]
 
+[pylama:cloudmarker/events/azkvsecretnoexpiryevent.py]
+ignore = R0201
+
+# R0201 Method could be a function [pylint]
+

--- a/pylama.ini
+++ b/pylama.ini
@@ -176,3 +176,7 @@ ignore = R0201
 
 # R0201 Method could be a function [pylint]
 
+[pylama:cloudmarker/events/azkvkeynoexpiryevent.py]
+ignore = R0201
+
+# R0201 Method could be a function [pylint]

--- a/pylama.ini
+++ b/pylama.ini
@@ -161,3 +161,13 @@ ignore = R0201
 ignore = R0201
 
 # R0201 Method could be a function [pylint]
+
+[pylama:cloudmarker/clouds/azkv.py]
+ignore = R0913,W0613,R0914
+
+# R0913 Too many arguments (8/5) [pylint]
+# W0613 Unused argument 'server' [pylint]
+# W0613 Unused argument 'resource' [pylint]
+# W0613 Unused argument 'scope' [pylint]
+# R0914 Too many local variables (17/15) [pylint]
+

--- a/usr-requirements.txt
+++ b/usr-requirements.txt
@@ -1,4 +1,6 @@
+azure-keyvault
 azure-mgmt-compute
+azure-mgmt-keyvault
 azure-mgmt-monitor
 azure-mgmt-network
 azure-mgmt-rdbms


### PR DESCRIPTION
The cloud plugin `AzKV` defines the methods to pull Key Vault management (key vault configuration) and data plane (keys, secrets ...) information from the Microsoft Azure cloud.

`AzKVSecretNoExpiryEvent` event plugin evaluates Azure Key Vault secrets and creates an event of type `key_vault_secret_no_expiry_event` for every secret for which no
expiration date is set.

`AzKVKeyNoExpiryEvent` event plugin evaluates Azure Key Vault keys and creates an event of type `key_vault_key_no_expiry_event` for every key for which no expiration date is set.

`AzKVNonRecoverableEvent` event plugin evaluates an Azure Key Vault and generates an event of type `key_vault_non_recoverable_event` if the Key Vault is not recoverable. An Azure Key Vault is deemed non-recoverable if `soft delete` and `purge protection` is not enabled for that Key Vault.