### PR TITLE
Added AzLogProfileMissingLocationEvent plugin

### DIFF
--- a/cloudmarker/baseconfig.py
+++ b/cloudmarker/baseconfig.py
@@ -69,7 +69,7 @@ plugins:
     plugin: cloudmarker.events.azkvnonrecoverableevent.AzKVNonRecoverableEvent
 
   azlogprofilemissinglocationevent:
-    plugin:cloudmarker.events.azlogprofilemissingcategoryevent.AzLogProfileLocationCategoryEvent
+    plugin: arachnoid.events.azlogprofilemissinglocationevent.AzLogProfileMissingLocationEvent
 
   mockevent:
     plugin: cloudmarker.events.mockevent.MockEvent

--- a/cloudmarker/baseconfig.py
+++ b/cloudmarker/baseconfig.py
@@ -68,6 +68,9 @@ plugins:
   azkvnonrecoverableevent:
     plugin: cloudmarker.events.azkvnonrecoverableevent.AzKVNonRecoverableEvent
 
+  azlogprofilemissinglocationevent:
+    plugin:cloudmarker.events.azlogprofilemissingcategoryevent.AzLogProfileLocationCategoryEvent
+
   mockevent:
     plugin: cloudmarker.events.mockevent.MockEvent
 

--- a/cloudmarker/clouds/azmonitor.py
+++ b/cloudmarker/clouds/azmonitor.py
@@ -92,6 +92,13 @@ class AzMonitor:
                 # Each record type for each subscription is a unit of
                 # work that would be fed to _get_resources().
                 for attribute_type in monitor_attributes:
+                    if attribute_type == 'log_profile':
+                        sub['locations'] = list()
+                        locations = sub_client.subscriptions. \
+                            list_locations(sub.get('subscription_id'))
+                        for location in locations:
+                            sub['locations'].append(location.as_dict()
+                                                    .get('name'))
                     yield (attribute_type, sub_index, sub)
 
                 # Break after pulling data for self._max_subs number of
@@ -225,6 +232,10 @@ def _get_record(iterator, attribute_type, max_recs,
                 'reference': raw_record.get('id'),
             }
         })
+        if 'locations' in sub:
+            record['ext']['subscription_locations'] = sub.get('locations')
+        if attribute_type == 'log_profile':
+            record['ext']['locations'] = raw_record.get('locations')
 
         # We have found at least one record, so we set this flag to False.
         records_missing = False

--- a/cloudmarker/clouds/azmonitor.py
+++ b/cloudmarker/clouds/azmonitor.py
@@ -93,7 +93,7 @@ class AzMonitor:
                 # work that would be fed to _get_resources().
                 for attribute_type in monitor_attributes:
                     if attribute_type == 'log_profile':
-                        sub['locations'] = list()
+                        sub['locations'] = []
                         locations = sub_client.subscriptions. \
                             list_locations(sub.get('subscription_id'))
                         for location in locations:
@@ -233,8 +233,10 @@ def _get_record(iterator, attribute_type, max_recs,
             }
         })
         if 'locations' in sub:
+            # Record the locations in which the subscription exists.
             record['ext']['subscription_locations'] = sub.get('locations')
         if attribute_type == 'log_profile':
+            # Record the locations in which the log profile is enabled.
             record['ext']['locations'] = raw_record.get('locations')
 
         # We have found at least one record, so we set this flag to False.

--- a/cloudmarker/events/azlogprofilemissinglocationevent.py
+++ b/cloudmarker/events/azlogprofilemissinglocationevent.py
@@ -1,0 +1,124 @@
+"""Microsoft Azure Log Profile Missing Location Event.
+
+This module defines the :class:`AzLogProfileMissingLocationEvent` class
+that identifies if a log profile which is not enable for all the supported
+locations/regions for that subscrition including ``global``. This plugin
+works on the log profile properties found in the ``ext`` bucket of
+``log_profile`` records.
+"""
+
+
+import logging
+
+from cloudmarker import util
+
+_log = logging.getLogger(__name__)
+
+
+class AzLogProfileMissingLocationEvent:
+    """Azure log profile missing location event plugin."""
+
+    def __init__(self):
+        """Create an instance of the class.
+
+        Create an instance of the
+        :class:`AzLogProfileMissingLocationEvent`.
+        """
+
+    def eval(self, record):
+        """Evaluate Azure log profiles for enabled locations.
+
+        Arguments:
+            record (dict): An Azure log profile record.
+
+        Yields:
+            dict: An event record representing an Azure log profile
+            which is not enabled for all locations including global.
+
+        """
+        com = record.get('com', {})
+        if com is None:
+            return
+
+        if com.get('cloud_type') != 'azure':
+            return
+
+        if com.get('record_type') != 'log_profile':
+            return
+
+        ext = record.get('ext', {})
+        if ext is None:
+            return
+
+        yield from _evaluate_log_profile_for_location(com, ext)
+
+    def done(self):
+        """Perform cleanup work.
+
+        Currently, this method does nothing. This may change in future.
+        """
+
+
+def _evaluate_log_profile_for_location(com, ext):
+    """Evaluate log profile for missing locations.
+
+    Arguments:
+        com (dict): Log profile record `com` bucket
+        ext (dict): Log profile record `ext` bucket
+
+    Yields:
+        dict: An event record representing a log profile which is not enabled
+              for all locations.
+
+    """
+    available_locations = set(ext.get('subscription_locations'))
+    available_locations.add('global')
+    missing_locations = available_locations - set(ext.get('locations'))
+    if not missing_locations:
+        return
+    yield _get_log_profile_missing_location_event(com, ext, missing_locations)
+
+
+def _get_log_profile_missing_location_event(com, ext, missing_locations):
+    """Generate log profile missing category type event.
+
+    Arguments:
+        com (dict): Log profile record `com` bucket
+        ext (dict): Log profile record `ext` bucket
+        missing_locations (set): Missing location set
+    Returns:
+        dict: An event record representing log profile which is not enabled
+        for all locations.
+
+    """
+    friendly_cloud_type = util.friendly_string(com.get('cloud_type'))
+    reference = com.get('reference')
+    description = (
+        '{} log profile {} does not include locations {}.'
+        .format(friendly_cloud_type, reference,
+                util.friendly_list(missing_locations))
+    )
+    recommendation = (
+        'Check {} log profile {} and enable locations {}.'
+        .format(friendly_cloud_type, reference,
+                util.friendly_list(missing_locations))
+    )
+    event_record = {
+        # Preserve the extended properties from the log profile
+        # record because they provide useful context to locate
+        # the log profile that led to the event.
+        'ext': util.merge_dicts(ext, {
+            'record_type': 'log_profile_missing_location_event',
+            'missing_locations': missing_locations
+        }),
+        'com': {
+            'cloud_type': com.get('cloud_type'),
+            'record_type': 'log_profile_missing_location_event',
+            'reference': reference,
+            'description': description,
+            'recommendation': recommendation,
+        }
+    }
+    _log.info('Generating log_profile_missing_location_event; %r',
+              event_record)
+    return event_record

--- a/cloudmarker/events/azlogprofilemissinglocationevent.py
+++ b/cloudmarker/events/azlogprofilemissinglocationevent.py
@@ -73,7 +73,7 @@ def _evaluate_log_profile_for_location(com, ext):
     """
     available_locations = set(ext.get('subscription_locations'))
     available_locations.add('global')
-    missing_locations = available_locations - set(ext.get('locations'))
+    missing_locations = list(available_locations - set(ext.get('locations')))
     if not missing_locations:
         return
     yield _get_log_profile_missing_location_event(com, ext, missing_locations)

--- a/cloudmarker/test/test_azlogprofilemissinglocationevent.py
+++ b/cloudmarker/test/test_azlogprofilemissinglocationevent.py
@@ -1,0 +1,99 @@
+"""Tests for AzLogProfileMissingLocationEvent plugin."""
+
+
+import copy
+import unittest
+
+from cloudmarker.events import azlogprofilemissinglocationevent
+
+base_log_profile_id = '/subscriptions/foo_sub_id/providers/\
+                    microsoft.insights/logprofiles/foo_lp_name'
+
+base_record = {
+    'com':  {
+        'cloud_type':  'azure',
+        'record_type': 'log_profile',
+        'reference': base_log_profile_id,
+    },
+    'ext': {
+        'reference': base_log_profile_id,
+        'subscription_locations': [],
+        'locations': [],
+    },
+    'raw': {
+        'categories': [],
+    }
+}
+
+
+class AzLogProfileMissingLocationEventTest(unittest.TestCase):
+    """Tests for AzLogProfileMissingLocationEvent plugin."""
+
+    def test_com_bucket_missing(self):
+        record = copy.deepcopy(base_record)
+        record['com'] = None
+        plugin = azlogprofilemissinglocationevent. \
+            AzLogProfileMissingLocationEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_com_bucket_cloud_type_non_azure(self):
+        record = copy.deepcopy(base_record)
+        record['com']['cloud_type'] = 'non_azure'
+        plugin = azlogprofilemissinglocationevent. \
+            AzLogProfileMissingLocationEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_com_bucket_record_type_non_log_profile(self):
+        record = copy.deepcopy(base_record)
+        record['com']['record_type'] = 'non_log_profile'
+        plugin = azlogprofilemissinglocationevent. \
+            AzLogProfileMissingLocationEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_ext_bucket_missing(self):
+        record = copy.deepcopy(base_record)
+        record['ext'] = None
+        plugin = azlogprofilemissinglocationevent. \
+            AzLogProfileMissingLocationEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_global_location_available(self):
+        record = copy.deepcopy(base_record)
+        record['ext']['locations'] = ['global']
+        plugin = azlogprofilemissinglocationevent. \
+            AzLogProfileMissingLocationEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(len(events), 0)
+
+    def test_global_location_not_available(self):
+        record = copy.deepcopy(base_record)
+        plugin = azlogprofilemissinglocationevent. \
+            AzLogProfileMissingLocationEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0]['ext']['record_type'],
+                         'log_profile_missing_location_event')
+        self.assertEqual(events[0]['com']['record_type'],
+                         'log_profile_missing_location_event')
+        self.assertEqual(events[0]['com']['cloud_type'], 'azure')
+        self.assertEqual(events[0]['com']['reference'], base_log_profile_id)
+
+    def test_all_location_not_available(self):
+        record = copy.deepcopy(base_record)
+        record['ext']['subscription_locations'] = \
+            ['loc_1, loc_2']
+        record['ext']['locations'] = ['global', 'loc_1']
+        plugin = azlogprofilemissinglocationevent. \
+            AzLogProfileMissingLocationEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0]['ext']['record_type'],
+                         'log_profile_missing_location_event')
+        self.assertEqual(events[0]['com']['record_type'],
+                         'log_profile_missing_location_event')
+        self.assertEqual(events[0]['com']['cloud_type'], 'azure')
+        self.assertEqual(events[0]['com']['reference'], base_log_profile_id)

--- a/pylama.ini
+++ b/pylama.ini
@@ -185,3 +185,8 @@ ignore = R0201
 ignore = R0201
 
 # R0201 Method could be a function [pylint]
+
+[pylama:cloudmarker/events/azlogprofilemissinglocationevent.py]
+ignore = R0201
+
+# R0201 Method could be a function [pylint]


### PR DESCRIPTION
An Azure log profile must capture events for all the available
locations, so that activity logs from all the locations are available
for incident response and investigation.

As many of the events in the activity logs are global events, a log
profile must also be enabled for `global` location.

This event plugin evaluates records of type `log_profile` and generates
an event of type `log_profile_missing_location_event` if a log profile
is not enabled for any of the available location/region for that
subscription including `global`.