### PR TITLE
Do not use import statements in test methods

### DIFF
--- a/cloudmarker/test/test_main.py
+++ b/cloudmarker/test/test_main.py
@@ -1,6 +1,7 @@
 """Tests for package execution."""
 
 
+import importlib
 import unittest
 from unittest import mock
 
@@ -12,5 +13,5 @@ class MainTest(unittest.TestCase):
     def test_main(self):
         # Run cloudmarker package with only the default base
         # configuration and ensure that it runs without issues.
-        import cloudmarker.__main__
-        self.assertEqual(type(cloudmarker.__main__).__name__, 'module')
+        module = importlib.import_module('cloudmarker.__main__')
+        self.assertEqual(type(module).__name__, 'module')

--- a/cloudmarker/test/test_setup.py
+++ b/cloudmarker/test/test_setup.py
@@ -2,6 +2,7 @@
 
 
 import glob
+import importlib
 import shutil
 import unittest
 from unittest import mock
@@ -18,7 +19,7 @@ class MainTest(unittest.TestCase):
 
     @mock.patch('sys.argv', ['setup.py', 'sdist', 'bdist_wheel'])
     def test_setup(self):
-        import setup
-        self.assertEqual(type(setup).__name__, 'module')
+        module = importlib.import_module('setup')
+        self.assertEqual(type(module).__name__, 'module')
         self.assertEqual(len(glob.glob('dist/*.whl')), 1)
         self.assertEqual(len(glob.glob('dist/*.tar.gz')), 1)


### PR DESCRIPTION
With the recent release of Pylint 2.4.0, the following errors appear
while running `make lint`:

    cloudmarker/test/test_setup.py:21:8:
    C0415 Import outside toplevel (setup) [pylint]

    cloudmarker/test/test_main.py:15:8:
    C0415 Import outside toplevel (cloudmarker.__main__) [pylint]

These errors occur because there are `import` statements inside test
methods. These errors have been resolved by replacing `import`
statements (which are indeed non-idiomatic inside test methods) with
`importlib.import_module()` calls.