### PR TITLE
Remove import statements in test methods

### DIFF
--- a/cloudmarker/test/test_mongodbstore.py
+++ b/cloudmarker/test/test_mongodbstore.py
@@ -4,6 +4,8 @@
 import unittest
 from unittest import mock
 
+from pymongo import errors
+
 from cloudmarker.stores import mongodbstore
 
 
@@ -57,7 +59,6 @@ class MongoDBStoreTest(unittest.TestCase):
 
     @mock.patch('cloudmarker.stores.mongodbstore.MongoClient')
     def test_bulk_write_error(self, mock_client):
-        from pymongo import errors
 
         # Configure the mock client such that it raises BulkWriteError
         # on insertion of records.


### PR DESCRIPTION
The following error is encountered while executing `make lint`:
cloudmarker/test/test_mongodbstore.py:60:8:
C0415 Import outside toplevel (pymongo) [pylint]

These errors occur because there are `import` statements inside test
methods. These errors have been resolved by replacing `import`
statements (which are indeed non-idiomatic inside test methods) with
`importlib.import_module()` calls.