### PR TITLE
Pin Azure KeyVault dependency version

### DIFF
--- a/usr-requirements.txt
+++ b/usr-requirements.txt
@@ -1,6 +1,6 @@
-azure-keyvault
+azure-keyvault==1.1.0
 azure-mgmt-compute
-azure-mgmt-keyvault
+azure-mgmt-keyvault==2.0.0
 azure-mgmt-monitor
 azure-mgmt-network
 azure-mgmt-rdbms


### PR DESCRIPTION
Pinned the version of azure-mgmt-keyvault to 2.0.0 and azure-keyvault to
1.1.0 to fix build issues.