### PR TITLE
Azure Postgres event plugins

### DIFF
--- a/cloudmarker/baseconfig.py
+++ b/cloudmarker/baseconfig.py
@@ -77,6 +77,9 @@ plugins:
   azpostgreslogconnectionsevent:
     plugin: cloudmarker.events.azpostgreslogconnectionsevent.AzPostgresLogConnectionsEvent
 
+  azpostgreslogdisconnectionsevent:
+    plugin: cloudmarker.events.azpostgreslogdisconnectionsevent.AzPostgresLogDisconnectionsEvent
+
   mockevent:
     plugin: cloudmarker.events.mockevent.MockEvent
 

--- a/cloudmarker/baseconfig.py
+++ b/cloudmarker/baseconfig.py
@@ -74,6 +74,9 @@ plugins:
   azpostgreslogcheckpointsevent:
     plugin: cloudmarker.events.azpostgreslogcheckpointsevent.AzPostgresLogCheckpointsEvent
 
+  azpostgreslogconnectionsevent:
+    plugin: cloudmarker.events.azpostgreslogconnectionsevent.AzPostgresLogConnectionsEvent
+
   mockevent:
     plugin: cloudmarker.events.mockevent.MockEvent
 

--- a/cloudmarker/baseconfig.py
+++ b/cloudmarker/baseconfig.py
@@ -80,6 +80,9 @@ plugins:
   azpostgreslogdisconnectionsevent:
     plugin: cloudmarker.events.azpostgreslogdisconnectionsevent.AzPostgresLogDisconnectionsEvent
 
+  azpostgreslogdurationevent:
+    plugin: cloudmarker.events.azpostgreslogdurationevent.AzPostgresLogDurationEvent
+
   mockevent:
     plugin: cloudmarker.events.mockevent.MockEvent
 

--- a/cloudmarker/baseconfig.py
+++ b/cloudmarker/baseconfig.py
@@ -71,6 +71,9 @@ plugins:
   azlogprofilemissinglocationevent:
     plugin: arachnoid.events.azlogprofilemissinglocationevent.AzLogProfileMissingLocationEvent
 
+  azpostgreslogcheckpointsevent:
+    plugin: cloudmarker.events.azpostgreslogcheckpointsevent.AzPostgresLogCheckpointsEvent
+
   mockevent:
     plugin: cloudmarker.events.mockevent.MockEvent
 

--- a/cloudmarker/events/azpostgreslogcheckpointsevent.py
+++ b/cloudmarker/events/azpostgreslogcheckpointsevent.py
@@ -1,0 +1,106 @@
+"""Microsoft Azure Postgres Log Checkpoints event.
+
+This module defines the :class:`AzPostgresLogCheckpointsEvent` class
+that identifies Postgre SQL servers which log checkpoints configuration
+disabled. This plugin works on the  properties found in the ``com``
+bucket of ``postgresql_server`` records.
+"""
+
+
+import logging
+
+from cloudmarker import util
+
+_log = logging.getLogger(__name__)
+
+
+class AzPostgresLogCheckpointsEvent:
+    """Az Postgres log checkpoints event plugin."""
+
+    def __init__(self):
+        """Create an instance of :class:`AzPostgresLogCheckpointsEvent`."""
+
+    def eval(self, record):
+        """Evaluate Postgres for log checkpoints.
+
+        Arguments:
+            record (dict): An RDBMS record.
+
+        Yields:
+            dict: An event record representing a Postgres where
+            log checkpoints is disabled
+
+        """
+        com = record.get('com', {})
+        if com is None:
+            return
+
+        if com.get('cloud_type') != 'azure':
+            return
+
+        if com.get('record_type') != 'rdbms':
+            return
+
+        ext = record.get('ext', {})
+        if ext is None:
+            return
+
+        if ext.get('record_type') != 'postgresql_server':
+            return
+
+        # True, None, missing key or any other value will not
+        # genarated an event. An event will be generated only if
+        # the value of `postgresql_server` is False.
+        if ext.get('log_checkpoints_enabled') is False:
+            yield from _get_postgres_log_checkpoint_disabled_event(
+                com, ext)
+
+    def done(self):
+        """Perform cleanup work.
+
+        Currently, this method does nothing. This may change in future.
+        """
+
+
+def _get_postgres_log_checkpoint_disabled_event(com, ext):
+    """Generate event for Postgres log checkpoints disabled.
+
+    Arguments:
+        com (dict): Postgres record `com` bucket
+        ext (dict): Postgres record `ext` bucket
+    Returns:
+        dict: An event record representing Postgres server
+        with log checkpoints disabled
+
+    """
+    friendly_cloud_type = util.friendly_string(com.get('cloud_type'))
+    friendly_rdbms_type = util.friendly_string(ext.get('record_type'))
+
+    reference = com.get('reference')
+    description = (
+        '{} {} {} has log checkpoints disabled.'
+        .format(friendly_cloud_type, friendly_rdbms_type, reference)
+    )
+    recommendation = (
+        'Check {} {} {} and enable log checkpoints.'
+        .format(friendly_cloud_type, friendly_rdbms_type, reference)
+    )
+
+    event_record = {
+        # Preserve the extended properties from the RDBMS
+        # record because they provide useful context to
+        # locate the RDBMS that led to the event.
+        'ext': util.merge_dicts(ext, {
+            'record_type': 'postgres_log_checkpoints_event'
+        }),
+        'com': {
+            'cloud_type': com.get('cloud_type'),
+            'record_type': 'postgres_log_checkpoints_event',
+            'reference': reference,
+            'description': description,
+            'recommendation': recommendation,
+        }
+    }
+
+    _log.info('Generating postgres_log_checkpoints_event; %r', event_record)
+    yield event_record

--- a/cloudmarker/events/azpostgreslogconnectionsevent.py
+++ b/cloudmarker/events/azpostgreslogconnectionsevent.py
@@ -1,0 +1,106 @@
+"""Microsoft Azure Postgres Log Connections event.
+
+This module defines the :class:`AzPostgresLogConnectionsEvent` class
+that identifies Postgre SQL servers which log connections configuration
+disabled. This plugin works on the  properties found in the ``com``
+bucket of ``postgresql_server`` records.
+"""
+
+
+import logging
+
+from cloudmarker import util
+
+_log = logging.getLogger(__name__)
+
+
+class AzPostgresLogConnectionsEvent:
+    """Az Postgres log connections event plugin."""
+
+    def __init__(self):
+        """Create an instance of :class:`AzPostgresLogConnectionsEvent`."""
+
+    def eval(self, record):
+        """Evaluate Postgres for log connections.
+
+        Arguments:
+            record (dict): An RDBMS record.
+
+        Yields:
+            dict: An event record representing a Postgres where
+            log connections is disabled
+
+        """
+        com = record.get('com', {})
+        if com is None:
+            return
+
+        if com.get('cloud_type') != 'azure':
+            return
+
+        if com.get('record_type') != 'rdbms':
+            return
+
+        ext = record.get('ext', {})
+        if ext is None:
+            return
+
+        if ext.get('record_type') != 'postgresql_server':
+            return
+
+        # True, None, missing key or any other value will not
+        # genarated an event. An event will be generated only if
+        # the value of `postgresql_server` is False.
+        if ext.get('log_connections_enabled') is False:
+            yield from _get_postgres_log_connections_disabled_event(
+                com, ext)
+
+    def done(self):
+        """Perform cleanup work.
+
+        Currently, this method does nothing. This may change in future.
+        """
+
+
+def _get_postgres_log_connections_disabled_event(com, ext):
+    """Generate event for Postgres log connections disabled.
+
+    Arguments:
+        com (dict): Postgres record `com` bucket
+        ext (dict): Postgres record `ext` bucket
+    Returns:
+        dict: An event record representing Postgres server
+        with log connections disabled
+
+    """
+    friendly_cloud_type = util.friendly_string(com.get('cloud_type'))
+    friendly_rdbms_type = util.friendly_string(ext.get('record_type'))
+
+    reference = com.get('reference')
+    description = (
+        '{} {} {} has log connections disabled.'
+        .format(friendly_cloud_type, friendly_rdbms_type, reference)
+    )
+    recommendation = (
+        'Check {} {} {} and enable log connections.'
+        .format(friendly_cloud_type, friendly_rdbms_type, reference)
+    )
+
+    event_record = {
+        # Preserve the extended properties from the RDBMS
+        # record because they provide useful context to
+        # locate the RDBMS that led to the event.
+        'ext': util.merge_dicts(ext, {
+            'record_type': 'postgres_log_connections_event'
+        }),
+        'com': {
+            'cloud_type': com.get('cloud_type'),
+            'record_type': 'postgres_log_connections_event',
+            'reference': reference,
+            'description': description,
+            'recommendation': recommendation,
+        }
+    }
+
+    _log.info('Generating postgres_log_connections_event; %r', event_record)
+    yield event_record

--- a/cloudmarker/events/azpostgreslogdisconnectionsevent.py
+++ b/cloudmarker/events/azpostgreslogdisconnectionsevent.py
@@ -1,0 +1,106 @@
+"""Microsoft Azure Postgres Log Disconnections event.
+
+This module defines the :class:`AzPostgresLogDisconnectionsEvent` class
+that identifies Postgre SQL servers which log disconnections configuration
+disabled. This plugin works on the  properties found in the ``com``
+bucket of ``postgresql_server`` records.
+"""
+
+
+import logging
+
+from cloudmarker import util
+
+_log = logging.getLogger(__name__)
+
+
+class AzPostgresLogDisconnectionsEvent:
+    """Az Postgres log disconnections event plugin."""
+
+    def __init__(self):
+        """Create an instance of :class:`AzPostgresLogDisconnectionsEvent`."""
+
+    def eval(self, record):
+        """Evaluate Postgres for log disconnections.
+
+        Arguments:
+            record (dict): An RDBMS record.
+
+        Yields:
+            dict: An event record representing a Postgres where
+            log disconnections is disabled
+
+        """
+        com = record.get('com', {})
+        if com is None:
+            return
+
+        if com.get('cloud_type') != 'azure':
+            return
+
+        if com.get('record_type') != 'rdbms':
+            return
+
+        ext = record.get('ext', {})
+        if ext is None:
+            return
+
+        if ext.get('record_type') != 'postgresql_server':
+            return
+
+        # True, None, missing key or any other value will not
+        # genarated an event. An event will be generated only if
+        # the value of `postgresql_server` is False.
+        if ext.get('log_disconnections_enabled') is False:
+            yield from _get_postgres_log_disconnections_disabled_event(
+                com, ext)
+
+    def done(self):
+        """Perform cleanup work.
+
+        Currently, this method does nothing. This may change in future.
+        """
+
+
+def _get_postgres_log_disconnections_disabled_event(com, ext):
+    """Generate event for Postgres log disconnections disabled.
+
+    Arguments:
+        com (dict): Postgres record `com` bucket
+        ext (dict): Postgres record `ext` bucket
+    Returns:
+        dict: An event record representing Postgres server
+        with log disconnections disabled
+
+    """
+    friendly_cloud_type = util.friendly_string(com.get('cloud_type'))
+    friendly_rdbms_type = util.friendly_string(ext.get('record_type'))
+
+    reference = com.get('reference')
+    description = (
+        '{} {} {} has log disconnections disabled.'
+        .format(friendly_cloud_type, friendly_rdbms_type, reference)
+    )
+    recommendation = (
+        'Check {} {} {} and enable log disconnections.'
+        .format(friendly_cloud_type, friendly_rdbms_type, reference)
+    )
+
+    event_record = {
+        # Preserve the extended properties from the RDBMS
+        # record because they provide useful context to
+        # locate the RDBMS that led to the event.
+        'ext': util.merge_dicts(ext, {
+            'record_type': 'postgres_log_disconnections_event'
+        }),
+        'com': {
+            'cloud_type': com.get('cloud_type'),
+            'record_type': 'postgres_log_disconnections_event',
+            'reference': reference,
+            'description': description,
+            'recommendation': recommendation,
+        }
+    }
+
+    _log.info('Generating postgres_log_disconnections_event; %r', event_record)
+    yield event_record

--- a/cloudmarker/events/azpostgreslogdurationevent.py
+++ b/cloudmarker/events/azpostgreslogdurationevent.py
@@ -1,0 +1,106 @@
+"""Microsoft Azure Postgres Log Duration event.
+
+This module defines the :class:`AzPostgresLogDurationEvent` class
+that identifies Postgre SQL servers which log duration configuration
+disabled. This plugin works on the  properties found in the ``com``
+bucket of ``postgresql_server`` records.
+"""
+
+
+import logging
+
+from cloudmarker import util
+
+_log = logging.getLogger(__name__)
+
+
+class AzPostgresLogDurationEvent:
+    """Az Postgres log duration event plugin."""
+
+    def __init__(self):
+        """Create an instance of :class:`AzPostgresLogDurationEvent`."""
+
+    def eval(self, record):
+        """Evaluate Postgres for log duration.
+
+        Arguments:
+            record (dict): An RDBMS record.
+
+        Yields:
+            dict: An event record representing a Postgres where
+            log duration is disabled
+
+        """
+        com = record.get('com', {})
+        if com is None:
+            return
+
+        if com.get('cloud_type') != 'azure':
+            return
+
+        if com.get('record_type') != 'rdbms':
+            return
+
+        ext = record.get('ext', {})
+        if ext is None:
+            return
+
+        if ext.get('record_type') != 'postgresql_server':
+            return
+
+        # True, None, missing key or any other value will not
+        # genarated an event. An event will be generated only if
+        # the value of `postgresql_server` is False.
+        if ext.get('log_duration_enabled') is False:
+            yield from _get_postgres_log_duration_disabled_event(
+                com, ext)
+
+    def done(self):
+        """Perform cleanup work.
+
+        Currently, this method does nothing. This may change in future.
+        """
+
+
+def _get_postgres_log_duration_disabled_event(com, ext):
+    """Generate event for Postgres log duration disabled.
+
+    Arguments:
+        com (dict): Postgres record `com` bucket
+        ext (dict): Postgres record `ext` bucket
+    Returns:
+        dict: An event record representing Postgres server
+        with log duration disabled
+
+    """
+    friendly_cloud_type = util.friendly_string(com.get('cloud_type'))
+    friendly_rdbms_type = util.friendly_string(ext.get('record_type'))
+
+    reference = com.get('reference')
+    description = (
+        '{} {} {} has log duration disabled.'
+        .format(friendly_cloud_type, friendly_rdbms_type, reference)
+    )
+    recommendation = (
+        'Check {} {} {} and enable log duration.'
+        .format(friendly_cloud_type, friendly_rdbms_type, reference)
+    )
+
+    event_record = {
+        # Preserve the extended properties from the RDBMS
+        # record because they provide useful context to
+        # locate the RDBMS that led to the event.
+        'ext': util.merge_dicts(ext, {
+            'record_type': 'postgres_log_duration_event'
+        }),
+        'com': {
+            'cloud_type': com.get('cloud_type'),
+            'record_type': 'postgres_log_duration_event',
+            'reference': reference,
+            'description': description,
+            'recommendation': recommendation,
+        }
+    }
+
+    _log.info('Generating postgres_log_duration_event; %r', event_record)
+    yield event_record

--- a/cloudmarker/test/test_azpostgreslogcheckpointsevent.py
+++ b/cloudmarker/test/test_azpostgreslogcheckpointsevent.py
@@ -1,0 +1,79 @@
+"""Tests for AzPostgresLogCheckpointsEvent plugin."""
+
+
+import copy
+import unittest
+
+from cloudmarker.events import azpostgreslogcheckpointsevent
+
+base_record = {
+    'com':  {
+        'cloud_type': 'azure',
+        'record_type': 'rdbms',
+    },
+    'ext': {
+        'record_type': 'postgresql_server',
+        'log_checkpoints_enabled': False
+    }
+}
+
+
+class AzPostgresLogCheckpointsEventTest(unittest.TestCase):
+    """Tests for AzPostgresLogCheckpointsEvent plugin."""
+
+    def test_com_bucket_missing(self):
+        record = copy.deepcopy(base_record)
+        record['com'] = None
+        plugin = azpostgreslogcheckpointsevent.AzPostgresLogCheckpointsEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_cloud_non_azure(self):
+        record = copy.deepcopy(base_record)
+        record['com']['cloud_type'] = 'non_azure'
+        plugin = azpostgreslogcheckpointsevent.AzPostgresLogCheckpointsEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_record_type_non_rdbms(self):
+        record = copy.deepcopy(base_record)
+        record['com']['record_type'] = 'non_rdbms'
+        plugin = azpostgreslogcheckpointsevent.AzPostgresLogCheckpointsEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_ext_bucket_missing(self):
+        record = copy.deepcopy(base_record)
+        record['ext'] = None
+        plugin = azpostgreslogcheckpointsevent.AzPostgresLogCheckpointsEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_record_type_non_postgresql_server(self):
+        record = copy.deepcopy(base_record)
+        record['ext']['record_type'] = 'non_postgresql_server'
+        plugin = azpostgreslogcheckpointsevent.AzPostgresLogCheckpointsEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_log_checkpoints_enabled(self):
+        record = copy.deepcopy(base_record)
+        record['ext']['log_checkpoints_enabled'] = True
+        plugin = azpostgreslogcheckpointsevent.AzPostgresLogCheckpointsEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_log_checkpoints_disabled(self):
+        record = copy.deepcopy(base_record)
+        plugin = azpostgreslogcheckpointsevent.AzPostgresLogCheckpointsEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0]['ext']['record_type'],
+                         'postgres_log_checkpoints_event')
+        self.assertEqual(events[0]['com']['cloud_type'],
+                         'azure')
+        self.assertEqual(events[0]['com']['record_type'],
+                         'postgres_log_checkpoints_event')
+        self.assertTrue('reference' in events[0]['com'])
+        self.assertIsNotNone(events[0]['com']['description'])
+        self.assertIsNotNone(events[0]['com']['recommendation'])

--- a/cloudmarker/test/test_azpostgreslogconnectionsevent.py
+++ b/cloudmarker/test/test_azpostgreslogconnectionsevent.py
@@ -1,0 +1,79 @@
+"""Tests for AzPostgresLogConnectionsEvent plugin."""
+
+
+import copy
+import unittest
+
+from cloudmarker.events import azpostgreslogconnectionsevent
+
+base_record = {
+    'com':  {
+        'cloud_type': 'azure',
+        'record_type': 'rdbms',
+    },
+    'ext': {
+        'record_type': 'postgresql_server',
+        'log_connections_enabled': False
+    }
+}
+
+
+class AzPostgresLogCheckpointsEventTest(unittest.TestCase):
+    """Tests for AzPostgresLogConnectionsEvent plugin."""
+
+    def test_com_bucket_missing(self):
+        record = copy.deepcopy(base_record)
+        record['com'] = None
+        plugin = azpostgreslogconnectionsevent.AzPostgresLogConnectionsEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_cloud_non_azure(self):
+        record = copy.deepcopy(base_record)
+        record['com']['cloud_type'] = 'non_azure'
+        plugin = azpostgreslogconnectionsevent.AzPostgresLogConnectionsEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_record_type_non_rdbms(self):
+        record = copy.deepcopy(base_record)
+        record['com']['record_type'] = 'non_rdbms'
+        plugin = azpostgreslogconnectionsevent.AzPostgresLogConnectionsEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_ext_bucket_missing(self):
+        record = copy.deepcopy(base_record)
+        record['ext'] = None
+        plugin = azpostgreslogconnectionsevent.AzPostgresLogConnectionsEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_record_type_non_postgresql_server(self):
+        record = copy.deepcopy(base_record)
+        record['ext']['record_type'] = 'non_postgresql_server'
+        plugin = azpostgreslogconnectionsevent.AzPostgresLogConnectionsEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_log_connection_enabled(self):
+        record = copy.deepcopy(base_record)
+        record['ext']['log_connections_enabled'] = True
+        plugin = azpostgreslogconnectionsevent.AzPostgresLogConnectionsEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_log_connections_disabled(self):
+        record = copy.deepcopy(base_record)
+        plugin = azpostgreslogconnectionsevent.AzPostgresLogConnectionsEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0]['ext']['record_type'],
+                         'postgres_log_connections_event')
+        self.assertEqual(events[0]['com']['cloud_type'],
+                         'azure')
+        self.assertEqual(events[0]['com']['record_type'],
+                         'postgres_log_connections_event')
+        self.assertTrue('reference' in events[0]['com'])
+        self.assertIsNotNone(events[0]['com']['description'])
+        self.assertIsNotNone(events[0]['com']['recommendation'])

--- a/cloudmarker/test/test_azpostgreslogdisconnectionsevent.py
+++ b/cloudmarker/test/test_azpostgreslogdisconnectionsevent.py
@@ -1,0 +1,86 @@
+"""Tests for AzPostgresLogDisconnectionsEvent plugin."""
+
+
+import copy
+import unittest
+
+from cloudmarker.events import azpostgreslogdisconnectionsevent
+
+base_record = {
+    'com':  {
+        'cloud_type': 'azure',
+        'record_type': 'rdbms',
+    },
+    'ext': {
+        'record_type': 'postgresql_server',
+        'log_disconnections_enabled': False
+    }
+}
+
+
+class AzPostgresLogDisconnectionsEventTest(unittest.TestCase):
+    """Tests for AzPostgresLogDisconnectionsEvent plugin."""
+
+    def test_com_bucket_missing(self):
+        record = copy.deepcopy(base_record)
+        record['com'] = None
+        plugin = azpostgreslogdisconnectionsevent. \
+            AzPostgresLogDisconnectionsEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_cloud_non_azure(self):
+        record = copy.deepcopy(base_record)
+        record['com']['cloud_type'] = 'non_azure'
+        plugin = azpostgreslogdisconnectionsevent. \
+            AzPostgresLogDisconnectionsEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_record_type_non_rdbms(self):
+        record = copy.deepcopy(base_record)
+        record['com']['record_type'] = 'non_rdbms'
+        plugin = azpostgreslogdisconnectionsevent. \
+            AzPostgresLogDisconnectionsEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_ext_bucket_missing(self):
+        record = copy.deepcopy(base_record)
+        record['ext'] = None
+        plugin = azpostgreslogdisconnectionsevent. \
+            AzPostgresLogDisconnectionsEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_record_type_non_postgresql_server(self):
+        record = copy.deepcopy(base_record)
+        record['ext']['record_type'] = 'non_postgresql_server'
+        plugin = azpostgreslogdisconnectionsevent. \
+            AzPostgresLogDisconnectionsEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_log_disconnections_enabled(self):
+        record = copy.deepcopy(base_record)
+        record['ext']['log_disconnections_enabled'] = True
+        plugin = azpostgreslogdisconnectionsevent. \
+            AzPostgresLogDisconnectionsEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_log_disconnections_disabled(self):
+        record = copy.deepcopy(base_record)
+        plugin = azpostgreslogdisconnectionsevent. \
+            AzPostgresLogDisconnectionsEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0]['ext']['record_type'],
+                         'postgres_log_disconnections_event')
+        self.assertEqual(events[0]['com']['cloud_type'],
+                         'azure')
+        self.assertEqual(events[0]['com']['record_type'],
+                         'postgres_log_disconnections_event')
+        self.assertTrue('reference' in events[0]['com'])
+        self.assertIsNotNone(events[0]['com']['description'])
+        self.assertIsNotNone(events[0]['com']['recommendation'])

--- a/cloudmarker/test/test_azpostgreslogdurationevent.py
+++ b/cloudmarker/test/test_azpostgreslogdurationevent.py
@@ -1,0 +1,79 @@
+"""Tests for AzPostgresLogDurationEvent plugin."""
+
+
+import copy
+import unittest
+
+from cloudmarker.events import azpostgreslogdurationevent
+
+base_record = {
+    'com':  {
+        'cloud_type': 'azure',
+        'record_type': 'rdbms',
+    },
+    'ext': {
+        'record_type': 'postgresql_server',
+        'log_duration_enabled': False
+    }
+}
+
+
+class AzPostgresLogCheckpointsEventTest(unittest.TestCase):
+    """Tests for AzPostgresLogDurationEvent plugin."""
+
+    def test_com_bucket_missing(self):
+        record = copy.deepcopy(base_record)
+        record['com'] = None
+        plugin = azpostgreslogdurationevent.AzPostgresLogDurationEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_cloud_non_azure(self):
+        record = copy.deepcopy(base_record)
+        record['com']['cloud_type'] = 'non_azure'
+        plugin = azpostgreslogdurationevent.AzPostgresLogDurationEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_record_type_non_rdbms(self):
+        record = copy.deepcopy(base_record)
+        record['com']['record_type'] = 'non_rdbms'
+        plugin = azpostgreslogdurationevent.AzPostgresLogDurationEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_ext_bucket_missing(self):
+        record = copy.deepcopy(base_record)
+        record['ext'] = None
+        plugin = azpostgreslogdurationevent.AzPostgresLogDurationEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_record_type_non_postgresql_server(self):
+        record = copy.deepcopy(base_record)
+        record['ext']['record_type'] = 'non_postgresql_server'
+        plugin = azpostgreslogdurationevent.AzPostgresLogDurationEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_log_duration_enabled(self):
+        record = copy.deepcopy(base_record)
+        record['ext']['log_duration_enabled'] = True
+        plugin = azpostgreslogdurationevent.AzPostgresLogDurationEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_log_duration_disabled(self):
+        record = copy.deepcopy(base_record)
+        plugin = azpostgreslogdurationevent.AzPostgresLogDurationEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0]['ext']['record_type'],
+                         'postgres_log_duration_event')
+        self.assertEqual(events[0]['com']['cloud_type'],
+                         'azure')
+        self.assertEqual(events[0]['com']['record_type'],
+                         'postgres_log_duration_event')
+        self.assertTrue('reference' in events[0]['com'])
+        self.assertIsNotNone(events[0]['com']['description'])
+        self.assertIsNotNone(events[0]['com']['recommendation'])

--- a/docs/api/cloudmarker.events.rst
+++ b/docs/api/cloudmarker.events.rst
@@ -73,6 +73,14 @@ cloudmarker.events.azpostgreslogcheckpointsevent module
    :undoc-members:
    :show-inheritance:
 
+cloudmarker.events.azpostgreslogconnectionsevent module
+-------------------------------------------------------
+
+.. automodule:: cloudmarker.events.azpostgreslogconnectionsevent
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 cloudmarker.events.azsqldatabasetdeevent module
 -----------------------------------------------
 

--- a/docs/api/cloudmarker.events.rst
+++ b/docs/api/cloudmarker.events.rst
@@ -89,6 +89,14 @@ cloudmarker.events.azpostgreslogdisconnectionsevent module
    :undoc-members:
    :show-inheritance:
 
+cloudmarker.events.azpostgreslogdurationevent module
+----------------------------------------------------
+
+.. automodule:: cloudmarker.events.azpostgreslogdurationevent
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 cloudmarker.events.azsqldatabasetdeevent module
 -----------------------------------------------
 

--- a/docs/api/cloudmarker.events.rst
+++ b/docs/api/cloudmarker.events.rst
@@ -81,6 +81,14 @@ cloudmarker.events.azpostgreslogconnectionsevent module
    :undoc-members:
    :show-inheritance:
 
+cloudmarker.events.azpostgreslogdisconnectionsevent module
+----------------------------------------------------------
+
+.. automodule:: cloudmarker.events.azpostgreslogdisconnectionsevent
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 cloudmarker.events.azsqldatabasetdeevent module
 -----------------------------------------------
 

--- a/docs/api/cloudmarker.events.rst
+++ b/docs/api/cloudmarker.events.rst
@@ -65,6 +65,14 @@ cloudmarker.events.azlogprofileretentionevent module
    :undoc-members:
    :show-inheritance:
 
+cloudmarker.events.azpostgreslogcheckpointsevent module
+-------------------------------------------------------
+
+.. automodule:: cloudmarker.events.azpostgreslogcheckpointsevent
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 cloudmarker.events.azsqldatabasetdeevent module
 -----------------------------------------------
 

--- a/pylama.ini
+++ b/pylama.ini
@@ -196,3 +196,8 @@ ignore = R0913,R0201
 
 # R0913 Too many arguments (8/5) [pylint]
 # R0201 Method could be a function [pylint]
+
+[pylama:cloudmarker/events/azpostgreslogcheckpointsevent.py]
+ignore = R0201
+
+# R0201 Method could be a function [pylint]

--- a/pylama.ini
+++ b/pylama.ini
@@ -206,3 +206,8 @@ ignore = R0201
 ignore = R0201
 
 # R0201 Method could be a function [pylint]
+
+[pylama:cloudmarker/events/azpostgreslogdisconnectionsevent.py]
+ignore = R0201
+
+# R0201 Method could be a function [pylint]

--- a/pylama.ini
+++ b/pylama.ini
@@ -211,3 +211,8 @@ ignore = R0201
 ignore = R0201
 
 # R0201 Method could be a function [pylint]
+
+[pylama:cloudmarker/events/azpostgreslogdurationevent.py]
+ignore = R0201
+
+# R0201 Method could be a function [pylint]

--- a/pylama.ini
+++ b/pylama.ini
@@ -201,3 +201,8 @@ ignore = R0913,R0201
 ignore = R0201
 
 # R0201 Method could be a function [pylint]
+
+[pylama:cloudmarker/events/azpostgreslogconnectionsevent.py]
+ignore = R0201
+
+# R0201 Method could be a function [pylint]


### PR DESCRIPTION
Add four Azure Postgres related event plugins. These are :

**1. AzPostgresLogCheckpointsEvent**
This plugin evaluates Azure Postgres instances can generates and event of type
`postgres_log_checkpoints_event` if the `log_checkpoints` setting is
disabled.Enabling `log_checkpoints` will generate error and query logs. These
logs can be used for troubleshooting and query optimization.

**2. AzPostgresLogConnectionsEvent** 
This plugin evaluates Azure Postgres instances can generates and event of type
`postgres_log_connections_event` if the `log_connections` setting is disabled.
Enabling `log_connections` helps PostgreSQL Database to log attempted
connection to the server, as well as successful completion of client authentication
successful completion of client authentication. These logs can be used for
troubleshooting and query optimization.

**3. AzPostgresLogDisconnectionsEvent.**
This plugin evaluates Azure Postgres instances can generates and event of type
`postgres_log_disconnections_event` if the `log_disconnections` setting is
disabled.
Enabling `log_disconnections` helps PostgreSQL Database to log end of session
including duration. These logs can be used for troubleshooting and query optimization.

**4. AzPostgresLogDurationEvent**
This plugin evaluates Azure Postgres instances can generates and
event of type `postgres_log_duration_event` if the `log_duration`
setting is disabled.
Enabling log_duration helps the PostgreSQL Database to Logs the duration
of each completed SQL statement which in turn generates query and error
logs. Query and error logs can be used to identify, troubleshoot, and repair
configuration errors and sub-optimal performance.