### PR TITLE
Add Azure Postgres plugins

### DIFF
--- a/cloudmarker/baseconfig.py
+++ b/cloudmarker/baseconfig.py
@@ -83,6 +83,9 @@ plugins:
   azpostgreslogdurationevent:
     plugin: cloudmarker.events.azpostgreslogdurationevent.AzPostgresLogDurationEvent
 
+  azpostgresconnectionthrottlingevent:
+    plugin: cloudmarker.events.azpostgresconnectionthrottlingevent.AzPostgresConnectionThrottlingEvent
+
   mockevent:
     plugin: cloudmarker.events.mockevent.MockEvent
 

--- a/cloudmarker/baseconfig.py
+++ b/cloudmarker/baseconfig.py
@@ -86,6 +86,9 @@ plugins:
   azpostgresconnectionthrottlingevent:
     plugin: cloudmarker.events.azpostgresconnectionthrottlingevent.AzPostgresConnectionThrottlingEvent
 
+  azpostgreslogretentiondaysevent:
+    plugin: cloudmarker.events.azpostgreslogretentiondaysevent.AzPostgresLogRetentionDaysEvent
+
   mockevent:
     plugin: cloudmarker.events.mockevent.MockEvent
 

--- a/cloudmarker/events/azpostgresconnectionthrottlingevent.py
+++ b/cloudmarker/events/azpostgresconnectionthrottlingevent.py
@@ -1,0 +1,107 @@
+"""Microsoft Azure Postgres Connection Throttling event.
+
+This module defines the :class:`AzPostgresConnectionThrottlingEvent` class
+that identifies Postgre SQL servers which connection throttling configuration
+disabled. This plugin works on the  properties found in the ``com``
+bucket of ``postgresql_server`` records.
+"""
+
+
+import logging
+
+from cloudmarker import util
+
+_log = logging.getLogger(__name__)
+
+
+class AzPostgresConnectionThrottlingEvent:
+    """Az Postgres connection throttling event plugin."""
+
+    def __init__(self):
+        """Create instance of :class:`AzPostgresConnectionThrottlingEvent`."""
+
+    def eval(self, record):
+        """Evaluate Postgres for connection throttling.
+
+        Arguments:
+            record (dict): An RDBMS record.
+
+        Yields:
+            dict: An event record representing a Postgres where
+            connection throttling is disabled
+
+        """
+        com = record.get('com', {})
+        if com is None:
+            return
+
+        if com.get('cloud_type') != 'azure':
+            return
+
+        if com.get('record_type') != 'rdbms':
+            return
+
+        ext = record.get('ext', {})
+        if ext is None:
+            return
+
+        if ext.get('record_type') != 'postgresql_server':
+            return
+
+        # True, None, missing key or any other value will not
+        # genarated an event. An event will be generated only if
+        # the value of `postgresql_server` is False.
+        if ext.get('connection_throttling_enabled') is False:
+            yield from _get_postgres_connection_throttling_disabled_event(
+                com, ext)
+
+    def done(self):
+        """Perform cleanup work.
+
+        Currently, this method does nothing. This may change in future.
+        """
+
+
+def _get_postgres_connection_throttling_disabled_event(com, ext):
+    """Generate event for Postgres connection throttling disabled.
+
+    Arguments:
+        com (dict): Postgres record `com` bucket
+        ext (dict): Postgres record `ext` bucket
+    Returns:
+        dict: An event record representing Postgres server
+        with connection throttling disabled
+
+    """
+    friendly_cloud_type = util.friendly_string(com.get('cloud_type'))
+    friendly_rdbms_type = util.friendly_string(ext.get('record_type'))
+
+    reference = com.get('reference')
+    description = (
+        '{} {} {} has connection throttling disabled.'
+        .format(friendly_cloud_type, friendly_rdbms_type, reference)
+    )
+    recommendation = (
+        'Check {} {} {} and enable connection throttling.'
+        .format(friendly_cloud_type, friendly_rdbms_type, reference)
+    )
+
+    event_record = {
+        # Preserve the extended properties from the RDBMS
+        # record because they provide useful context to
+        # locate the RDBMS that led to the event.
+        'ext': util.merge_dicts(ext, {
+            'record_type': 'postgres_connection_throttling_event'
+        }),
+        'com': {
+            'cloud_type': com.get('cloud_type'),
+            'record_type': 'postgres_connection_throttling_event',
+            'reference': reference,
+            'description': description,
+            'recommendation': recommendation,
+        }
+    }
+
+    _log.info('Generating postgres_connection_throttling_event; %r',
+              event_record)
+    yield event_record

--- a/cloudmarker/events/azpostgreslogretentiondaysevent.py
+++ b/cloudmarker/events/azpostgreslogretentiondaysevent.py
@@ -1,0 +1,115 @@
+"""Microsoft Azure Postgres Log Retention Days event.
+
+This module defines the :class:`AzPostgresLogRetentionDaysEvent` class
+that identifies Postgre SQL servers which have log retention days set
+below the desired minimum value. This plugin works on the  properties
+found in the ``com`` bucket of ``postgresql_server`` records.
+"""
+
+
+import logging
+
+from cloudmarker import util
+
+_log = logging.getLogger(__name__)
+
+
+class AzPostgresLogRetentionDaysEvent:
+    """Az Postgres log retention days event plugin."""
+
+    def __init__(self, _min_log_retention_days=3):
+        """Create instance of :class:`AzPostgresLogRetentionDaysEvent`."""
+        self._min_log_retention_days = _min_log_retention_days
+        _log.info("Initialized; minimum log retention days: %d",
+                  self._min_log_retention_days)
+
+    def eval(self, record):
+        """Evaluate Postgres for log retention days.
+
+        Arguments:
+            record (dict): An RDBMS record.
+            _min_log_retention_days (int): Minimum required log retention days.
+
+        Yields:
+            dict: An event record representing a Postgres where
+            log retention days is set below desired minimum
+
+        """
+        com = record.get('com', {})
+        if com is None:
+            return
+
+        if com.get('cloud_type') != 'azure':
+            return
+
+        if com.get('record_type') != 'rdbms':
+            return
+
+        ext = record.get('ext', {})
+        if ext is None:
+            return
+
+        if ext.get('record_type') != 'postgresql_server':
+            return
+
+        # True, None, missing key or any other value will not
+        # genarated an event. An event will be generated only if
+        # the value of `postgresql_server` is False.
+        log_retention_days = ext.get('log_retention_days')
+
+        if log_retention_days < self._min_log_retention_days:
+            yield from _get_postgres_log_retention_days_event(
+                com, ext, self._min_log_retention_days)
+
+    def done(self):
+        """Perform cleanup work.
+
+        Currently, this method does nothing. This may change in future.
+        """
+
+
+def _get_postgres_log_retention_days_event(com, ext, min_log_retention_days):
+    """Generate event for Postgres log retention days set below minimum.
+
+    Arguments:
+        com (dict): Postgres record `com` bucket
+        ext (dict): Postgres record `ext` bucket
+        min_log_retention_days (int): Minimum log retention days
+    Returns:
+        dict: An event record representing Postgres server
+        with log retention days set below desired minimum.
+
+    """
+    friendly_cloud_type = util.friendly_string(com.get('cloud_type'))
+    friendly_rdbms_type = util.friendly_string(ext.get('record_type'))
+
+    reference = com.get('reference')
+    description = (
+        '{} {} {} has log retention days set below desired minimum value.'
+        .format(friendly_cloud_type, friendly_rdbms_type, reference)
+    )
+    recommendation = (
+        'Check {} {} {} and set log retention days to minimum of {} days.'
+        .format(friendly_cloud_type, friendly_rdbms_type, reference,
+                min_log_retention_days)
+    )
+
+    event_record = {
+        # Preserve the extended properties from the RDBMS
+        # record because they provide useful context to
+        # locate the RDBMS that led to the event.
+        'ext': util.merge_dicts(ext, {
+            'record_type': 'postgres_log_retention_days_event'
+        }),
+        'com': {
+            'cloud_type': com.get('cloud_type'),
+            'record_type': 'postgres_log_retention_days_event',
+            'reference': reference,
+            'description': description,
+            'recommendation': recommendation,
+        }
+    }
+
+    _log.info('Generating postgres_log_retention_days_event; %r',
+              event_record)
+    yield event_record

--- a/cloudmarker/test/test_azpostgresconnectionthrotthingevent.py
+++ b/cloudmarker/test/test_azpostgresconnectionthrotthingevent.py
@@ -1,0 +1,86 @@
+"""Tests for AzPostgresConnectionThrottlingEvent plugin."""
+
+
+import copy
+import unittest
+
+from cloudmarker.events import azpostgresconnectionthrottlingevent
+
+base_record = {
+    'com':  {
+        'cloud_type': 'azure',
+        'record_type': 'rdbms',
+    },
+    'ext': {
+        'record_type': 'postgresql_server',
+        'connection_throttling_enabled': False
+    }
+}
+
+
+class AzPostgresConnectionThrottlingEventTest(unittest.TestCase):
+    """Tests for AzPostgresConnectionThrottlingEventTest plugin."""
+
+    def test_com_bucket_missing(self):
+        record = copy.deepcopy(base_record)
+        record['com'] = None
+        plugin = azpostgresconnectionthrottlingevent. \
+            AzPostgresConnectionThrottlingEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_cloud_non_azure(self):
+        record = copy.deepcopy(base_record)
+        record['com']['cloud_type'] = 'non_azure'
+        plugin = azpostgresconnectionthrottlingevent. \
+            AzPostgresConnectionThrottlingEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_record_type_non_rdbms(self):
+        record = copy.deepcopy(base_record)
+        record['com']['record_type'] = 'non_rdbms'
+        plugin = azpostgresconnectionthrottlingevent. \
+            AzPostgresConnectionThrottlingEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_ext_bucket_missing(self):
+        record = copy.deepcopy(base_record)
+        record['ext'] = None
+        plugin = azpostgresconnectionthrottlingevent. \
+            AzPostgresConnectionThrottlingEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_record_type_non_postgresql_server(self):
+        record = copy.deepcopy(base_record)
+        record['ext']['record_type'] = 'non_postgresql_server'
+        plugin = azpostgresconnectionthrottlingevent. \
+            AzPostgresConnectionThrottlingEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_connection_throttling_enabled(self):
+        record = copy.deepcopy(base_record)
+        record['ext']['connection_throttling_enabled'] = True
+        plugin = azpostgresconnectionthrottlingevent. \
+            AzPostgresConnectionThrottlingEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(events, [])
+
+    def test_connection_throttling_disenabled(self):
+        record = copy.deepcopy(base_record)
+        plugin = azpostgresconnectionthrottlingevent. \
+            AzPostgresConnectionThrottlingEvent()
+        events = list(plugin.eval(record))
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0]['ext']['record_type'],
+                         'postgres_connection_throttling_event')
+        self.assertEqual(events[0]['com']['cloud_type'],
+                         'azure')
+        self.assertEqual(events[0]['com']['record_type'],
+                         'postgres_connection_throttling_event')
+        self.assertTrue('reference' in events[0]['com'])
+        self.assertIsNotNone(events[0]['com']['description'])
+        self.assertIsNotNone(events[0]['com']['recommendation'])

--- a/docs/api/cloudmarker.events.rst
+++ b/docs/api/cloudmarker.events.rst
@@ -105,6 +105,14 @@ cloudmarker.events.azpostgresconnectionthrottlingevent module
    :undoc-members:
    :show-inheritance:
 
+cloudmarker.events.azpostgreslogretentiondaysevent module
+---------------------------------------------------------
+
+.. automodule:: cloudmarker.events.azpostgreslogretentiondaysevent
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 cloudmarker.events.azsqldatabasetdeevent module
 -----------------------------------------------
 

--- a/docs/api/cloudmarker.events.rst
+++ b/docs/api/cloudmarker.events.rst
@@ -97,6 +97,14 @@ cloudmarker.events.azpostgreslogdurationevent module
    :undoc-members:
    :show-inheritance:
 
+cloudmarker.events.azpostgresconnectionthrottlingevent module
+-------------------------------------------------------------
+
+.. automodule:: cloudmarker.events.azpostgresconnectionthrottlingevent
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 cloudmarker.events.azsqldatabasetdeevent module
 -----------------------------------------------
 

--- a/pylama.ini
+++ b/pylama.ini
@@ -221,3 +221,8 @@ ignore = R0201
 ignore = R0201
 
 # R0201 Method could be a function [pylint]
+
+[pylama:cloudmarker/events/azpostgreslogretentiondaysevent.py]
+ignore = R0201
+
+# R0201 Method could be a function [pylint]

--- a/pylama.ini
+++ b/pylama.ini
@@ -216,3 +216,8 @@ ignore = R0201
 ignore = R0201
 
 # R0201 Method could be a function [pylint]
+
+[pylama:cloudmarker/events/azpostgresconnectionthrottlingevent.py]
+ignore = R0201
+
+# R0201 Method could be a function [pylint]


### PR DESCRIPTION
This PR contains two event plugins related to Azure Postgres.
These are:

**1. AzPostgresConnectionThrottlingEvent** plugin
evaluates Azure Postgres instances can generates and event of type
`postgres_connection_throttling_event` if the `connection_throttling` is
disabled.

Enabling connection_throttling helps the PostgreSQL Database to Set
the verbosity of logged messages which in turn generates query and error
logs with respect to concurrent connections, that could lead to a
successful Denial of Service (DoS) attack by exhausting connection
resources.

**2. AzPostgresLogRetentionDaysEvent** plugin evaluates Azure Postgres
instance and  generates an event of type
`postgres_log_retention_days_event` if the `log_retention_days`
configuration is set below the desired minimum value. The minimum value
for this configuration can be set using the `_min_log_retention_days`
argument and defaults to 3 days.

Enabling log_retention_days helps PostgreSQL Database to Sets number
of days a log file is retained which in turn generates query and error
logs.