### PR TITLE
Remove Python 3.4 from the Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,8 @@
 language: python
 python:
-  - "3.4"
   - "3.5"
   - "3.6"
 install:
-  # Install the latest version of setuptools to work around a dependency
-  # resolution issue: https://github.com/cloudmarker/cloudmarker/pull/45
-  #
-  # TODO: Check once in a while if this workaround is still required.
-  - if [ "$TRAVIS_PYTHON_VERSION" = 3.4 ]; then pip install -U setuptools; fi
   - make deps
   - pip install coveralls
 script:


### PR DESCRIPTION
The Travis builds have been limited to Python 3.5 and 3.6
Python 3.4 has reached end of life and is no longer supported.