### PR TITLE
Add AzStorageAccountDefaultNetworkAccessEvent plugin

### DIFF
--- a/cloudmarker/clouds/azstorageaccount.py
+++ b/cloudmarker/clouds/azstorageaccount.py
@@ -209,6 +209,9 @@ def _process_storage_account_properties(storage_account_index,
 
     """
     storage_account['properties'] = storage_account_properties
+    default_network_access_allowed = True
+    if storage_account['network_rule_set'].get('default_action') != 'Allow':
+        default_network_access_allowed = False
     record = {
         'raw': storage_account,
         'ext': {
@@ -217,6 +220,7 @@ def _process_storage_account_properties(storage_account_index,
             'secure_transfer_required': storage_account_properties.get(
                 'enable_https_traffic_only'
             ),
+            'default_network_access_allowed': default_network_access_allowed,
             'subscription_id': sub.get('subscription_id'),
             'subscription_name': sub.get('display_name'),
             'subscription_state': sub.get('state'),

--- a/cloudmarker/events/azstorageaccountdefaultnetworkaccessevent.py
+++ b/cloudmarker/events/azstorageaccountdefaultnetworkaccessevent.py
@@ -1,0 +1,95 @@
+"""Microsoft storage account default network access event.
+
+This module defines the :class:`AzStorageAccountDefaultNetworkAccessEvent`
+class that identifies a storage account with default network access set to
+`Allow`. This plugin works on the storage account properties record
+found in the ``ext`` bucket of ``storage_account_properties`` records.
+"""
+
+
+import logging
+
+from cloudmarker import util
+
+_log = logging.getLogger(__name__)
+
+
+class AzStorageAccountDefaultNetworkAccessEvent:
+    """Azure storage account default network access event plugin."""
+
+    def __init__(self):
+        """Initialize :class:`AzStorageAccountDefaultNetworkAccessEvent`."""
+
+    def eval(self, record):
+        """Evaluate Azure storage account for default network access.
+
+        Arguments:
+            record (dict): A storage account record.
+
+        Yields:
+            dict: An event record representing a storage account with default
+            network access allowed.
+
+        """
+        com = record.get('com')
+        ext = record.get('ext')
+        if ext.get('record_type') != 'storage_account_properties':
+            return
+
+        default_network_access_allowed = \
+            ext.get('default_network_access_allowed')
+        if default_network_access_allowed is True:
+            yield from _get_az_storage_account_default_network_access_event(
+                com, ext)
+
+    def done(self):
+        """Perform cleanup work.
+
+        Currently, this method does nothing. This may change in future.
+
+        """
+
+
+def _get_az_storage_account_default_network_access_event(com, ext):
+    """Generate Azure storage account default network access event.
+
+    Arguments:
+        com (dict): Azure storage account record `com` bucket.
+        ext (dict): Azure storage account record `ext` bucket.
+
+    Returns:
+        dict: An event record representing storage accounts with default
+        network access set to allowed.
+
+    """
+    friendly_cloud_type = util.friendly_string(com.get('cloud_type'))
+    reference = com.get('reference')
+
+    description = (
+        '{} storage account {} has default network access set to allowed.'
+        .format(friendly_cloud_type, reference)
+    )
+    recommendation = (
+        'Check {} storage account {} and set default network access to deny.'
+        .format(friendly_cloud_type, reference)
+    )
+
+    event_record = {
+        # Preserve the  properties from the storage account
+        # record because they provide useful context to
+        # locate the storage account that led to the event.
+        'ext': util.merge_dicts(ext, {
+            'record_type': 'storage_account_default_network_access_event'
+        }),
+        'com': {
+            'cloud_type': com.get('cloud_type'),
+            'record_type': 'storage_account_default_network_access_event',
+            'reference': reference,
+            'description': description,
+            'recommendation': recommendation,
+        }
+    }
+
+    _log.info('Generating storage_account_default_network_access_event; %r',
+              event_record)
+    yield event_record

--- a/pylama.ini
+++ b/pylama.ini
@@ -226,3 +226,9 @@ ignore = R0201
 ignore = R0201
 
 # R0201 Method could be a function [pylint]
+
+[pylama:cloudmarker/events/azstorageaccountdefaultnetworkaccessevent.py]
+ignore = R0201
+
+# R0201 Method could be a function [pylint]
+


### PR DESCRIPTION
Added AzStorageAccountDefaultNetworkAccessEvent event plugin. This plugin evaluates an Azure storage acccount and generated an event of type `storage_account_default_network_access_event` if the storage account has default network access set to `Allow`.

Storage account access should be limited to a selected networks. To do so the default network access must be set to `Deny`.