### PR TITLE
Add AzStorageAccountAllowTrustedServicesEvent

### DIFF
--- a/cloudmarker/clouds/azstorageaccount.py
+++ b/cloudmarker/clouds/azstorageaccount.py
@@ -212,6 +212,13 @@ def _process_storage_account_properties(storage_account_index,
     default_network_access_allowed = True
     if storage_account['network_rule_set'].get('default_action') != 'Allow':
         default_network_access_allowed = False
+    # Azure services is an umbrella term for trusted Microsoft Azure services
+    # including Azure Backup, Azure Site Recovery, Azure DevTest Labs,
+    # Azure Event Grid, Azure Event Hubs, Azure Networking, Azure Monitor and
+    # Azure SQL Data Warehouse
+    bypass_trusted_services = True
+    if storage_account['network_rule_set'].get('bypass') != 'AzureServices':
+        bypass_trusted_services = False
     record = {
         'raw': storage_account,
         'ext': {
@@ -221,6 +228,7 @@ def _process_storage_account_properties(storage_account_index,
                 'enable_https_traffic_only'
             ),
             'default_network_access_allowed': default_network_access_allowed,
+            'trusted_services_allowed': bypass_trusted_services,
             'subscription_id': sub.get('subscription_id'),
             'subscription_name': sub.get('display_name'),
             'subscription_state': sub.get('state'),

--- a/cloudmarker/events/azstorageaccountallowtrustedservicesevent.py
+++ b/cloudmarker/events/azstorageaccountallowtrustedservicesevent.py
@@ -1,0 +1,96 @@
+"""Microsoft storage account allow trusted services event.
+
+This module defines the :class:`AzStorageAccountAllowTrustedServicesEvent`
+class that identifies a storage account with network access set to
+denied to Microsoft Azure services. This plugin works on the storage
+account properties record found in the ``ext`` bucket of
+``storage_account_properties`` records.
+"""
+
+
+import logging
+
+from cloudmarker import util
+
+_log = logging.getLogger(__name__)
+
+
+class AzStorageAccountAllowTrustedServicesEvent:
+    """Azure storage account allow trusted services event plugin."""
+
+    def __init__(self):
+        """Initialize :class:`AzStorageAccountAllowTrustedServicesEvent`."""
+
+    def eval(self, record):
+        """Evaluate Azure storage account for trusted services access.
+
+        Arguments:
+            record (dict): A storage account record.
+
+        Yields:
+            dict: An event record representing a storage account with Azure
+            services not allowed to access the storage account.
+
+        """
+        com = record.get('com')
+        ext = record.get('ext')
+        if ext.get('record_type') != 'storage_account_properties':
+            return
+
+        trusted_services_allowed = \
+            ext.get('trusted_services_allowed')
+        if trusted_services_allowed is False:
+            yield from _get_az_storage_account_allow_trusted_services_event(
+                com, ext)
+
+    def done(self):
+        """Perform cleanup work.
+
+        Currently, this method does nothing. This may change in future.
+
+        """
+
+
+def _get_az_storage_account_allow_trusted_services_event(com, ext):
+    """Generate Azure storage account allow trusted services event.
+
+    Arguments:
+        com (dict): Azure storage account record `com` bucket.
+        ext (dict): Azure storage account record `ext` bucket.
+
+    Returns:
+        dict: An event record representing storage accounts with Azure
+        services not allowed access.
+
+    """
+    friendly_cloud_type = util.friendly_string(com.get('cloud_type'))
+    reference = com.get('reference')
+
+    description = (
+        '{} storage account {} does not allow access to Azure services.'
+        .format(friendly_cloud_type, reference)
+    )
+    recommendation = (
+        'Check {} storage account {} and allow access to Azure services.'
+        .format(friendly_cloud_type, reference)
+    )
+
+    event_record = {
+        # Preserve the  properties from the storage account
+        # record because they provide useful context to
+        # locate the storage account that led to the event.
+        'ext': util.merge_dicts(ext, {
+            'record_type': 'storage_account_allow_trusted_services_event'
+        }),
+        'com': {
+            'cloud_type': com.get('cloud_type'),
+            'record_type': 'storage_account_allow_trusted_services_event',
+            'reference': reference,
+            'description': description,
+            'recommendation': recommendation,
+        }
+    }
+
+    _log.info('Generating storage_account_allow_trusted_services_event; %r',
+              event_record)
+    yield event_record

--- a/pylama.ini
+++ b/pylama.ini
@@ -253,3 +253,7 @@ ignore = R0913,W0703
 # R0913 Too many arguments (8/5) [pylint]
 # W0703 Catching too general exception Exception [pylint]
 
+[pylama:cloudmarker/events/azstorageaccountallowtrustedservicesevent.py]
+ignore = R0201
+
+# R0201 Method could be a function [pylint]


### PR DESCRIPTION
Added `AzStorageAccountAllowTrustedServicesEvent` event plugin. This
plugin evaluates Azure storage accounts and generates an event if
Microsoft Azure services are not allowed access.

From `CIS Microsoft Azure Foundations Benchmark v1.1.0`:

Some Microsoft services that interact with storage accounts operate
from networks that can't be granted access through network rules. To
help this type of service work as intended, allow the set of trusted
Microsoft services to bypass the network rules. These services will
then use strong authentication to access the storage account. If the
Allow trusted Microsoft services exception is enabled, the following
services: Azure Backup, Azure Site Recovery, Azure DevTest Labs,
Azure Event Grid, Azure Event Hubs, Azure Networking, Azure Monitor
and Azure SQL Data Warehouse (when registered in the subscription),
are granted access to the storage account.